### PR TITLE
bug fixes from migration of MGA to TP

### DIFF
--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
@@ -188,12 +188,9 @@ public class MemberInjectorProcessor extends ToothpickProcessor {
 
     for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
       TypeElement annotationTypeElement = (TypeElement) annotationMirror.getAnnotationType().asElement();
-      System.out.println("annotation detected" + annotationTypeElement);
       if (isSameType(annotationTypeElement, "javax.inject.Named")) {
-        System.out.println("named detected" + annotationTypeElement);
         checkIfAlreadyHasName(element, name);
         name = getValueOfAnnotation(annotationMirror);
-        System.out.println("name detected" + name);
       } else if (isAnnotationPresent(annotationTypeElement, "javax.inject.Qualifier")) {
         checkIfAlreadyHasName(element, name);
         name = annotationTypeElement.getQualifiedName().toString();

--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
@@ -199,6 +199,7 @@ public class MemberInjectorProcessor extends ToothpickProcessor {
     return name;
   }
 
+  //http://stackoverflow.com/a/36678792/693752
   private boolean isAnnotationPresent(TypeElement annotationTypeElement, String annotationName) {
     for (AnnotationMirror annotationOfAnnotationTypeMirror : annotationTypeElement.getAnnotationMirrors()) {
       TypeElement annotationOfAnnotationTypeElement = (TypeElement) annotationOfAnnotationTypeMirror.getAnnotationType().asElement();

--- a/toothpick-compiler/src/test/java/toothpick/compiler/memberinjector/FieldMemberInjectorTest.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/memberinjector/FieldMemberInjectorTest.java
@@ -2,7 +2,6 @@ package toothpick.compiler.memberinjector;
 
 import com.google.common.base.Joiner;
 import com.google.testing.compile.JavaFileObjects;
-import javax.inject.Qualifier;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
@@ -157,7 +156,6 @@ public class FieldMemberInjectorTest {
         .and()
         .generatesSources(expectedSource);
   }
-
 
   @Test
   public void testNamedProviderFieldInjection_whenUsingQualifierAnnotation() {

--- a/toothpick/src/main/java/toothpick/Scope.java
+++ b/toothpick/src/main/java/toothpick/Scope.java
@@ -111,7 +111,7 @@ public abstract class Scope {
         return allProviders.unNamedProvider;
       }
 
-      Map<Object, Provider> mapNameToProvider = (Map<Object, Provider>) allProviders.getMapNameToProvider();
+      Map<String, Provider> mapNameToProvider = (Map<String, Provider>) allProviders.getMapNameToProvider();
       if (mapNameToProvider == null) {
         return null;
       }
@@ -128,7 +128,7 @@ public abstract class Scope {
    * @param bindingName the name, possibly {@code null}, for which to install the scoped provider.
    * @param <T> the type of {@code clazz}.
    */
-  protected <T, U extends T> void installProvider(Class<T> clazz, Object bindingName, Provider<U> provider) {
+  protected <T, U extends T> void installProvider(Class<T> clazz, String bindingName, Provider<U> provider) {
     synchronized (clazz) {
       AllProviders allProviders = mapClassesToAllProviders.get(clazz);
       if (allProviders == null) {
@@ -138,7 +138,7 @@ public abstract class Scope {
       if (bindingName == null) {
         allProviders.setUnNamedProvider(provider);
       } else {
-        Map<Object, Provider> mapNameToProvider = allProviders.getMapNameToProvider();
+        Map<String, Provider> mapNameToProvider = allProviders.getMapNameToProvider();
         if (mapNameToProvider == null) {
           mapNameToProvider = new HashMap<>();
           allProviders.setMapNameToProvider(mapNameToProvider);
@@ -185,12 +185,12 @@ public abstract class Scope {
    * will be scoped in the root scope of the current scope.
    *
    * @param clazz the class for which to obtain an instance in the scope of this scope.
-   * @param name the name of this instance. TODO should we duplicate to allow only annotations and strings ? see bindings
+   * @param name the name of this instance.
    * @param <T> the type of {@code clazz}.
    * @return a scoped instance or a new one produced by the factory associated to {@code clazz}.
    * @see toothpick.config.Binding
    */
-  public abstract <T> T getInstance(Class<T> clazz, Object name);
+  public abstract <T> T getInstance(Class<T> clazz, String name);
 
   /**
    * Returns a named {@code Provider} of {@code clazz} if one is scoped in the current
@@ -201,11 +201,11 @@ public abstract class Scope {
    * will be scoped in the root scope of the current scope.
    *
    * @param clazz the class for which to obtain a provider in the scope of this scope.
-   * @param name the name of this instance. TODO should we duplicate to allow only annotations and strings ? see bindings
+   * @param name the name of this instance.
    * @param <T> the type of {@code clazz}.
    * @return a scoped provider or a new one using the factory associated to {@code clazz}.
    */
-  public abstract <T> Provider<T> getProvider(Class<T> clazz, Object name);
+  public abstract <T> Provider<T> getProvider(Class<T> clazz, String name);
 
   /**
    * Returns a {@code Lazy} of {@code clazz} if one provider is scoped in the current
@@ -221,6 +221,22 @@ public abstract class Scope {
    * @see #getProvider(Class)
    */
   public abstract <T> Lazy<T> getLazy(Class<T> clazz);
+
+  /**
+   * Returns a {@code Lazy} of {@code clazz} if one provider is scoped in the current
+   * scope, or its ancestors. If there is no such provider, the factory associated
+   * to the clazz will be used to create one.
+   * All {@link javax.inject.Inject} annotated fields of the instance are injected after creation.
+   * If the {@param clazz} is annotated with {@link javax.inject.Singleton} then the created provider
+   * will be scoped in the root scope of the current scope.
+   *
+   * @param clazz the class for which to obtain a lazy in the scope of this scope.
+   * @param name the name of this instance.
+   * @param <T> the type of {@code clazz}.
+   * @return a scoped lazy or a new one using the factory associated to {@code clazz}.
+   * @see #getProvider(Class)
+   */
+  public abstract <T> Lazy<T> getLazy(Class<T> clazz, String name);
 
   /**
    * Allows to define test modules. These method should only be used for testing.
@@ -286,22 +302,13 @@ public abstract class Scope {
 
   protected static class AllProviders<T> {
     private Provider<? extends T> unNamedProvider;
-    private Map<Object, Provider<? extends T>> mapNameToProvider;
+    private Map<String, Provider<? extends T>> mapNameToProvider;
 
-    public AllProviders() {
-      this(null, null);
-    }
-
-    public AllProviders(Provider<? extends T> unNamedProvider, Map<Object, Provider<? extends T>> mapNameToProvider) {
-      this.unNamedProvider = unNamedProvider;
-      this.mapNameToProvider = mapNameToProvider;
-    }
-
-    public Map<Object, Provider<? extends T>> getMapNameToProvider() {
+    public Map<String, Provider<? extends T>> getMapNameToProvider() {
       return mapNameToProvider;
     }
 
-    public void setMapNameToProvider(Map<Object, Provider<? extends T>> mapNameToProvider) {
+    public void setMapNameToProvider(Map<String, Provider<? extends T>> mapNameToProvider) {
       this.mapNameToProvider = mapNameToProvider;
     }
 

--- a/toothpick/src/main/java/toothpick/config/Binding.java
+++ b/toothpick/src/main/java/toothpick/config/Binding.java
@@ -2,6 +2,7 @@ package toothpick.config;
 
 import java.lang.annotation.Annotation;
 import javax.inject.Provider;
+import javax.inject.Qualifier;
 
 public class Binding<T> {
   private Class<T> key;
@@ -10,7 +11,7 @@ public class Binding<T> {
   private T instance;
   private Provider<T> providerInstance;
   private Class<? extends Provider<T>> providerClass;
-  private Object name;
+  private String name;
 
   public Binding(Class<T> key) {
     this.key = key;
@@ -22,8 +23,13 @@ public class Binding<T> {
     return this;
   }
 
-  public <A extends Annotation> Binding<T> withName(Class<A> name) {
-    this.name = name;
+  public <A extends Annotation> Binding<T> withName(Class<A> annotationClassWithQualifierAnnotation) {
+    if (!annotationClassWithQualifierAnnotation.isAnnotationPresent(Qualifier.class)) {
+      throw new IllegalArgumentException(
+          String.format("Only qualifier annotation annotations can be used to define a binding name. Add @Qualifier to %s",
+              annotationClassWithQualifierAnnotation));
+    }
+    this.name = annotationClassWithQualifierAnnotation.getClass().getName();
     return this;
   }
 
@@ -71,7 +77,7 @@ public class Binding<T> {
     return providerClass;
   }
 
-  public Object getName() {
+  public String getName() {
     return name;
   }
 


### PR DESCRIPTION
second batch. We now clear the naming system at large as we had some tech debt here. API looks much nicer and we could kill the usage of java.lang.Object.