### PR TITLE
fix toothpick-runtime dependencies in artifact pom

### DIFF
--- a/toothpick-testing/build.gradle
+++ b/toothpick-testing/build.gradle
@@ -8,4 +8,4 @@ dependencies {
   compile deps.junit
 }
 
-apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+//apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
If we allow this line to release the testing module then the pom of toothpick-runtime contains wrong dependencies.

Without the line :
```
<dependencies>
    <dependency>
      <groupId>toothpick</groupId>
      <artifactId>toothpick-generated-core</artifactId>
      <version>0.0.1-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>junit</groupId>
      <artifactId>junit</artifactId>
      <version>4.12</version>
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>toothpick</groupId>
      <artifactId>toothpick-compiler</artifactId>
      <version>0.0.1-SNAPSHOT</version>
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>org.powermock</groupId>
      <artifactId>powermock-easymock-release-full</artifactId>
      <version>1.6.4</version>
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>org.easymock</groupId>
      <artifactId>easymock</artifactId>
      <version>3.4</version>
      <scope>test</scope>
    </dependency>
  </dependencies>
```

With the line :
```
  <dependencies>
    <dependency>
      <groupId>junit</groupId>
      <artifactId>junit</artifactId>
      <version>4.12</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>toothpick</groupId>
      <artifactId>toothpick-runtime</artifactId>
      <version>0.0.1-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
```

I could not find any trace of this bug on the web. Sounds strange. Related to module names ? 
It looks like the maven plugin is gonna be deprecated anyway. Gradle 2.12 introduces a new maven-publish plugin that may fix the issue.

