### PR TITLE
Sni/lock free

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -112,7 +112,7 @@
     <module name="EqualsHashCode"/>
     <!--<module name="HiddenField"/>-->
     <module name="IllegalInstantiation"/>
-    <module name="InnerAssignment"/>
+    <!--module name="InnerAssignment"/-->
     <!--<module name="MagicNumber"/>-->
     <module name="MissingSwitchDefault"/>
     <module name="RedundantThrows"/>

--- a/toothpick-compiler/src/main/java/toothpick/compiler/common/generators/CodeGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/common/generators/CodeGenerator.java
@@ -11,6 +11,8 @@ import toothpick.compiler.common.generators.targets.ParamInjectionTarget;
  */
 public abstract class CodeGenerator {
 
+  protected static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
   /**
    * Creates all java code.
    *

--- a/toothpick-compiler/src/main/java/toothpick/compiler/factory/generators/FactoryGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/factory/generators/FactoryGenerator.java
@@ -82,7 +82,8 @@ public class FactoryGenerator extends CodeGenerator {
       TypeName paramType = TypeName.get(paramInjectionTarget.memberClass.asType());
       createInstanceBuilder.addCode("$T $L = scope.", paramType, paramName);
       createInstanceBuilder.addCode(invokeScopeGetMethodWithNameCodeBlock);
-      createInstanceBuilder.addCode(";\n");
+      createInstanceBuilder.addCode(";");
+      createInstanceBuilder.addCode(LINE_SEPARATOR);
       localVarStatement.append(prefix);
       localVarStatement.append(paramName);
       prefix = ", ";

--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.java
@@ -112,7 +112,8 @@ public class MemberInjectorGenerator extends CodeGenerator {
         TypeName paramType = TypeName.get(paramInjectionTarget.memberClass.asType());
         injectMethodBuilder.addCode("$T $L = scope.", paramType, paramName);
         injectMethodBuilder.addCode(invokeScopeGetMethodWithNameCodeBlock);
-        injectMethodBuilder.addCode(";\n");
+        injectMethodBuilder.addCode(";");
+        injectMethodBuilder.addCode(LINE_SEPARATOR);
         injectedMethodCallStatement.append(prefix);
         injectedMethodCallStatement.append(paramName);
         prefix = ", ";
@@ -131,7 +132,8 @@ public class MemberInjectorGenerator extends CodeGenerator {
       CodeBlock invokeScopeGetMethodWithNameCodeBlock = getInvokeScopeGetMethodWithNameCodeBlock(memberInjectionTarget);
       injectBuilder.addCode("target.$L = scope.", memberInjectionTarget.memberName);
       injectBuilder.addCode(invokeScopeGetMethodWithNameCodeBlock);
-      injectBuilder.addCode(";\n");
+      injectBuilder.addCode(";");
+      injectBuilder.addCode(LINE_SEPARATOR);
     }
   }
 

--- a/toothpick-compiler/src/main/java/toothpick/compiler/registry/generators/RegistryGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/registry/generators/RegistryGenerator.java
@@ -69,12 +69,12 @@ public class RegistryGenerator extends CodeGenerator {
     CodeBlock.Builder switchBlockBuilder = CodeBlock.builder().beginControlFlow("switch($L)", "clazz.getName().replace('$','.')");
 
     for (TypeElement injectionTarget : registryInjectionTarget.injectionTargetList) {
-      switchBlockBuilder.add("case ($S):\n", injectionTarget.getQualifiedName().toString());
+      switchBlockBuilder.add("case ($S):" + LINE_SEPARATOR, injectionTarget.getQualifiedName().toString());
       String typeSimpleName = registryInjectionTarget.type.getSimpleName();
       switchBlockBuilder.addStatement("return ($L<T>) new $L$$$$$L()", typeSimpleName, getGeneratedFQNClassName(injectionTarget), typeSimpleName);
     }
 
-    switchBlockBuilder.add("default:\n");
+    switchBlockBuilder.add("default:" + LINE_SEPARATOR);
     switchBlockBuilder.addStatement("return $L(clazz)", registryInjectionTarget.childrenGetterName);
     switchBlockBuilder.endControlFlow();
     getMethod.addCode(switchBlockBuilder.build());

--- a/toothpick-runtime/build.gradle
+++ b/toothpick-runtime/build.gradle
@@ -5,12 +5,14 @@ targetCompatibility = 1.7
 
 dependencies {
   compile project(':toothpick-generated-core')
+  //compile 'org.perf4j:perf4j:0.9.16'
 
   testCompile deps.junit
   testCompile project(':toothpick-compiler')
   testCompile deps.easymock
   testCompile deps.powermock
   testCompile deps.hamcrest
+  testCompile files(System.getenv("JAVA_HOME") + "/lib/tools.jar")
 }
 
 compileTestJava {

--- a/toothpick-runtime/src/main/java/toothpick/CyclicDependencyException.java
+++ b/toothpick-runtime/src/main/java/toothpick/CyclicDependencyException.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class CyclicDependencyException extends RuntimeException {
 
   private static final int MARGIN_SIZE = 3;
+  private static final String LINE_SEPARATOR = System.getProperty("line.separator");;
 
   public CyclicDependencyException() {
   }
@@ -26,7 +27,7 @@ public class CyclicDependencyException extends RuntimeException {
   }
 
   public CyclicDependencyException(List<Class> path, Class startClass) {
-    this(String.format("Class %s creates a cycle:\n%s", startClass.getName(), format(path, startClass)));
+    this(String.format("Class %s creates a cycle:%n%s", startClass.getName(), format(path, startClass)));
   }
 
   private static String format(List<Class> path, Class startClass) {
@@ -53,7 +54,7 @@ public class CyclicDependencyException extends RuntimeException {
   }
 
   private static void addTopLines(StringBuilder builder, int middleWordPos, int loopLinePosition) {
-    builder.append("\n");
+    builder.append(LINE_SEPARATOR);
     addHorizontalLine(builder, middleWordPos, loopLinePosition);
     addLine(builder, "||", middleWordPos, loopLinePosition);
     addLine(builder, "\\/", middleWordPos, loopLinePosition);
@@ -62,7 +63,7 @@ public class CyclicDependencyException extends RuntimeException {
   private static void addHorizontalLine(StringBuilder builder, int middleWordPos, int loopLinePosition) {
     builder.append(repeat(' ', middleWordPos));
     builder.append(repeat('=', loopLinePosition - middleWordPos + 1));
-    builder.append("\n");
+    builder.append(LINE_SEPARATOR);
   }
 
   private static void addLine(StringBuilder builder, String content, int middleWordPos, int loopLinePosition) {
@@ -71,7 +72,8 @@ public class CyclicDependencyException extends RuntimeException {
     builder.append(repeat(' ', leftMarginSize));
     builder.append(content);
     builder.append(repeat(' ', rightMarginSize));
-    builder.append("||\n");
+    builder.append("||");
+    builder.append(LINE_SEPARATOR);
   }
 
   private static int findLongestClassNameLength(List<Class> path) {

--- a/toothpick-runtime/src/main/java/toothpick/InternalProviderImpl.java
+++ b/toothpick-runtime/src/main/java/toothpick/InternalProviderImpl.java
@@ -9,10 +9,10 @@ import toothpick.registries.FactoryRegistryLocator;
  * @param <T> the class of the instances provided by this provider.
  */
 public class InternalProviderImpl<T> {
-  private T instance;
+  private volatile T instance;
   private Factory<T> factory;
   private Class<T> factoryClass;
-  private Provider<? extends T> providerInstance;
+  private volatile Provider<? extends T> providerInstance;
   private boolean isLazy;
   private Factory<Provider<T>> providerFactory;
   private Class<Provider<T>> providerFactoryClass;

--- a/toothpick-runtime/src/main/java/toothpick/registries/FactoryRegistryLocator.java
+++ b/toothpick-runtime/src/main/java/toothpick/registries/FactoryRegistryLocator.java
@@ -2,8 +2,6 @@ package toothpick.registries;
 
 import toothpick.Factory;
 
-import static java.lang.String.format;
-
 /**
  * Locates the {@link FactoryRegistry} instances.
  * The registries form a tree, or a forest (collection of disjoint trees).
@@ -43,8 +41,6 @@ public class FactoryRegistryLocator {
         return factory;
       }
     }
-    throw new RuntimeException(format("No factory could be found for class %s." //
-        + " Check that registries are properly setup with annotation processor arguments, " //
-        + "or use annotations correctly in this class.", clazz.getName()));
+    throw new NoFactoryFoundException(clazz);
   }
 }

--- a/toothpick-runtime/src/main/java/toothpick/registries/NoFactoryFoundException.java
+++ b/toothpick-runtime/src/main/java/toothpick/registries/NoFactoryFoundException.java
@@ -1,0 +1,11 @@
+package toothpick.registries;
+
+import static java.lang.String.format;
+
+public class NoFactoryFoundException extends RuntimeException {
+  public NoFactoryFoundException(Class clazz) {
+    super(format("No factory could be found for class %s." //
+        + " Check that registries are properly setup with annotation processor arguments, " //
+        + "or use annotations correctly in this class.", clazz.getName()));
+  }
+}

--- a/toothpick-runtime/src/main/java/toothpick/util/ConcurrentIdentityHashMap.java
+++ b/toothpick-runtime/src/main/java/toothpick/util/ConcurrentIdentityHashMap.java
@@ -1,0 +1,1411 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/licenses/publicdomain
+ */
+package toothpick.util;
+
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * An alternative identity-comparing {@link ConcurrentMap} which is similar to
+ * {@link ConcurrentHashMap}.
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ */
+public final class ConcurrentIdentityHashMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K, V> {
+
+  /**
+   * The default initial capacity for this table, used when not otherwise
+   * specified in a constructor.
+   */
+  static final int DEFAULT_INITIAL_CAPACITY = 16;
+
+  /**
+   * The default load factor for this table, used when not otherwise specified
+   * in a constructor.
+   */
+  static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+  /**
+   * The default concurrency level for this table, used when not otherwise
+   * specified in a constructor.
+   */
+  static final int DEFAULT_CONCURRENCY_LEVEL = 16;
+
+  /**
+   * The maximum capacity, used if a higher value is implicitly specified by
+   * either of the constructors with arguments.  MUST be a power of two
+   * &lt;= 1&lt;&lt;30 to ensure that entries are indexable using integers.
+   */
+  static final int MAXIMUM_CAPACITY = 1 << 30;
+
+  /**
+   * The maximum number of segments to allow; used to bound constructor
+   * arguments.
+   */
+  static final int MAX_SEGMENTS = 1 << 16; // slightly conservative
+
+  /**
+   * Number of unsynchronized retries in size and containsValue methods before
+   * resorting to locking. This is used to avoid unbounded retries if tables
+   * undergo continuous modification which would make it impossible to obtain
+   * an accurate result.
+   */
+  static final int RETRIES_BEFORE_LOCK = 2;
+
+    /* ---------------- Fields -------------- */
+
+  /**
+   * Mask value for indexing into segments. The upper bits of a key's hash
+   * code are used to choose the segment.
+   */
+  final int segmentMask;
+
+  /**
+   * Shift value for indexing within segments.
+   */
+  final int segmentShift;
+
+  /**
+   * The segments, each of which is a specialized hash table
+   */
+  final Segment<K, V>[] segments;
+
+  Set<K> keySet;
+  Set<Map.Entry<K, V>> entrySet;
+  Collection<V> values;
+
+    /* ---------------- Small Utilities -------------- */
+
+  /**
+   * Applies a supplemental hash function to a given hashCode, which defends
+   * against poor quality hash functions.  This is critical because
+   * ConcurrentReferenceHashMap uses power-of-two length hash tables, that
+   * otherwise encounter collisions for hashCodes that do not differ in lower
+   * or upper bits.
+   */
+  private static int hash(int h) {
+    // Spread bits to regularize both segment and index locations,
+    // using variant of single-word Wang/Jenkins hash.
+    h += h << 15 ^ 0xffffcd7d;
+    h ^= h >>> 10;
+    h += h << 3;
+    h ^= h >>> 6;
+    h += (h << 2) + (h << 14);
+    return h ^ h >>> 16;
+  }
+
+  /**
+   * Returns the segment that should be used for key with given hash.
+   *
+   * @param hash the hash code for the key
+   * @return the segment
+   */
+  Segment<K, V> segmentFor(int hash) {
+    return segments[hash >>> segmentShift & segmentMask];
+  }
+
+  private static int hashOf(Object key) {
+    return hash(System.identityHashCode(key));
+  }
+
+  /**
+   * ConcurrentReferenceHashMap list entry. Note that this is never exported
+   * out as a user-visible Map.Entry.
+   *
+   * Because the value field is volatile, not final, it is legal wrt
+   * the Java Memory Model for an unsynchronized reader to see null
+   * instead of initial value when read via a data race.  Although a
+   * reordering leading to this is not likely to ever actually
+   * occur, the Segment.readValueUnderLock method is used as a
+   * backup in case a null (pre-initialized) value is ever seen in
+   * an unsynchronized access method.
+   */
+  static final class HashEntry<K, V> {
+    final Object key;
+    final int hash;
+    volatile Object value;
+    final HashEntry<K, V> next;
+
+    HashEntry(K key, int hash, HashEntry<K, V> next, V value) {
+      this.hash = hash;
+      this.next = next;
+      this.key = key;
+      this.value = value;
+    }
+
+    @SuppressWarnings("unchecked")
+    K key() {
+      return (K) key;
+    }
+
+    @SuppressWarnings("unchecked")
+    V value() {
+      return (V) value;
+    }
+
+    void setValue(V value) {
+      this.value = value;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, V> HashEntry<K, V>[] newArray(int i) {
+      return new HashEntry[i];
+    }
+  }
+
+  /**
+   * Segments are specialized versions of hash tables.  This subclasses from
+   * ReentrantLock opportunistically, just to simplify some locking and avoid
+   * separate construction.
+   */
+  static final class Segment<K, V> extends ReentrantLock {
+        /*
+         * Segments maintain a table of entry lists that are ALWAYS kept in a
+         * consistent state, so can be read without locking. Next fields of
+         * nodes are immutable (final).  All list additions are performed at the
+         * front of each bin. This makes it easy to check changes, and also fast
+         * to traverse. When nodes would otherwise be changed, new nodes are
+         * created to replace them. This works well for hash tables since the
+         * bin lists tend to be short. (The average length is less than two for
+         * the default load factor threshold.)
+         *
+         * Read operations can thus proceed without locking, but rely on
+         * selected uses of volatiles to ensure that completed write operations
+         * performed by other threads are noticed. For most purposes, the
+         * "count" field, tracking the number of elements, serves as that
+         * volatile variable ensuring visibility.  This is convenient because
+         * this field needs to be read in many read operations anyway:
+         *
+         *   - All (unsynchronized) read operations must first read the
+         *     "count" field, and should not look at table entries if
+         *     it is 0.
+         *
+         *   - All (synchronized) write operations should write to
+         *     the "count" field after structurally changing any bin.
+         *     The operations must not take any action that could even
+         *     momentarily cause a concurrent read operation to see
+         *     inconsistent data. This is made easier by the nature of
+         *     the read operations in Map. For example, no operation
+         *     can reveal that the table has grown but the threshold
+         *     has not yet been updated, so there are no atomicity
+         *     requirements for this with respect to reads.
+         *
+         * As a guide, all critical volatile reads and writes to the count field
+         * are marked in code comments.
+         */
+
+    private static final long serialVersionUID = 5207829234977119743L;
+
+    /**
+     * The number of elements in this segment's region.
+     */
+    transient volatile int count;
+
+    /**
+     * Number of updates that alter the size of the table. This is used
+     * during bulk-read methods to make sure they see a consistent snapshot:
+     * If modCounts change during a traversal of segments computing size or
+     * checking containsValue, then we might have an inconsistent view of
+     * state so (usually) must retry.
+     */
+    int modCount;
+
+    /**
+     * The table is rehashed when its size exceeds this threshold.
+     * (The value of this field is always <tt>(capacity * loadFactor)</tt>.)
+     */
+    int threshold;
+
+    /**
+     * The per-segment table.
+     */
+    transient volatile HashEntry<K, V>[] table;
+
+    /**
+     * The load factor for the hash table.  Even though this value is same
+     * for all segments, it is replicated to avoid needing links to outer
+     * object.
+     */
+    final float loadFactor;
+
+    Segment(int initialCapacity, float lf) {
+      loadFactor = lf;
+      setTable(HashEntry.<K, V>newArray(initialCapacity));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <K, V> Segment<K, V>[] newArray(int i) {
+      return new Segment[i];
+    }
+
+    private static boolean keyEq(Object src, Object dest) {
+      return src == dest;
+    }
+
+    /**
+     * Sets table to new HashEntry array. Call only while holding lock or in
+     * constructor.
+     */
+    void setTable(HashEntry<K, V>[] newTable) {
+      threshold = (int) (newTable.length * loadFactor);
+      table = newTable;
+    }
+
+    /**
+     * Returns properly casted first entry of bin for given hash.
+     */
+    HashEntry<K, V> getFirst(int hash) {
+      HashEntry<K, V>[] tab = table;
+      return tab[hash & tab.length - 1];
+    }
+
+    HashEntry<K, V> newHashEntry(K key, int hash, HashEntry<K, V> next, V value) {
+      return new HashEntry<K, V>(key, hash, next, value);
+    }
+
+    /**
+     * Reads value field of an entry under lock. Called if value field ever
+     * appears to be null. This is possible only if a compiler happens to
+     * reorder a HashEntry initialization with its table assignment, which
+     * is legal under memory model but is not known to ever occur.
+     */
+    V readValueUnderLock(HashEntry<K, V> e) {
+      lock();
+      try {
+        return e.value();
+      } finally {
+        unlock();
+      }
+    }
+
+        /* Specialized implementations of map methods */
+
+    V get(Object key, int hash) {
+      if (count != 0) { // read-volatile
+        HashEntry<K, V>[] tab = table;
+        HashEntry<K, V> e = tab[hash & tab.length - 1];
+        if (tab != table) {
+          return get(key, hash);
+        }
+        while (e != null) {
+          if (e.hash == hash && keyEq(key, e.key())) {
+            V opaque = e.value();
+            if (opaque != null) {
+              return opaque;
+            }
+
+            return readValueUnderLock(e); // recheck
+          }
+          e = e.next;
+        }
+      }
+      return null;
+    }
+
+    boolean containsKey(Object key, int hash) {
+      if (count != 0) { // read-volatile
+        HashEntry<K, V>[] tab = table;
+        HashEntry<K, V> e = tab[hash & tab.length - 1];
+        if (tab != table) {
+          return containsKey(key, hash);
+        }
+        while (e != null) {
+          if (e.hash == hash && keyEq(key, e.key())) {
+            return true;
+          }
+          e = e.next;
+        }
+      }
+      return false;
+    }
+
+    boolean containsValue(Object value) {
+      if (count != 0) { // read-volatile
+        HashEntry<K, V>[] tab = table;
+        for (HashEntry<K, V> e : tab) {
+          for (; e != null; e = e.next) {
+            V opaque = e.value();
+            V v;
+
+            if (opaque == null) {
+              v = readValueUnderLock(e); // recheck
+            } else {
+              v = opaque;
+            }
+
+            if (value.equals(v)) {
+              return true;
+            }
+          }
+        }
+        if (table != tab) {
+          return containsValue(value);
+        }
+      }
+      return false;
+    }
+
+    boolean replace(K key, int hash, V oldValue, V newValue) {
+      lock();
+      try {
+        HashEntry<K, V> e = getFirst(hash);
+        while (e != null && (e.hash != hash || !keyEq(key, e.key()))) {
+          e = e.next;
+        }
+
+        boolean replaced = false;
+        if (e != null && oldValue.equals(e.value())) {
+          replaced = true;
+          e.setValue(newValue);
+        }
+        return replaced;
+      } finally {
+        unlock();
+      }
+    }
+
+    V replace(K key, int hash, V newValue) {
+      lock();
+      try {
+        HashEntry<K, V> e = getFirst(hash);
+        while (e != null && (e.hash != hash || !keyEq(key, e.key()))) {
+          e = e.next;
+        }
+
+        V oldValue = null;
+        if (e != null) {
+          oldValue = e.value();
+          e.setValue(newValue);
+        }
+        return oldValue;
+      } finally {
+        unlock();
+      }
+    }
+
+    V put(K key, int hash, V value, boolean onlyIfAbsent) {
+      lock();
+      try {
+        int c = count;
+        if (c++ > threshold) { // ensure capacity
+          int reduced = rehash();
+          if (reduced > 0) {
+            count = (c -= reduced) - 1; // write-volatile
+          }
+        }
+
+        HashEntry<K, V>[] tab = table;
+        int index = hash & tab.length - 1;
+        HashEntry<K, V> first = tab[index];
+        HashEntry<K, V> e = first;
+        while (e != null && (e.hash != hash || !keyEq(key, e.key()))) {
+          e = e.next;
+        }
+
+        V oldValue;
+        if (e != null) {
+          oldValue = e.value();
+          if (!onlyIfAbsent) {
+            e.setValue(value);
+          }
+        } else {
+          oldValue = null;
+          ++modCount;
+          tab[index] = newHashEntry(key, hash, first, value);
+          count = c; // write-volatile
+        }
+        return oldValue;
+      } finally {
+        unlock();
+      }
+    }
+
+    int rehash() {
+      HashEntry<K, V>[] oldTable = table;
+      int oldCapacity = oldTable.length;
+      if (oldCapacity >= MAXIMUM_CAPACITY) {
+        return 0;
+      }
+
+            /*
+             * Reclassify nodes in each list to new Map.  Because we are using
+             * power-of-two expansion, the elements from each bin must either
+             * stay at same index, or move with a power of two offset. We
+             * eliminate unnecessary node creation by catching cases where old
+             * nodes can be reused because their next fields won't change.
+             * Statistically, at the default threshold, only about one-sixth of
+             * them need cloning when a table doubles. The nodes they replace
+             * will be garbage collectable as soon as they are no longer
+             * referenced by any reader thread that may be in the midst of
+             * traversing table right now.
+             */
+
+      HashEntry<K, V>[] newTable = HashEntry.newArray(oldCapacity << 1);
+      threshold = (int) (newTable.length * loadFactor);
+      int sizeMask = newTable.length - 1;
+      int reduce = 0;
+      for (HashEntry<K, V> e : oldTable) {
+        // We need to guarantee that any existing reads of old Map can
+        // proceed. So we cannot yet null out each bin.
+        if (e != null) {
+          HashEntry<K, V> next = e.next;
+          int idx = e.hash & sizeMask;
+
+          // Single node on list
+          if (next == null) {
+            newTable[idx] = e;
+          } else {
+            // Reuse trailing consecutive sequence at same slot
+            HashEntry<K, V> lastRun = e;
+            int lastIdx = idx;
+            for (HashEntry<K, V> last = next; last != null; last = last.next) {
+              int k = last.hash & sizeMask;
+              if (k != lastIdx) {
+                lastIdx = k;
+                lastRun = last;
+              }
+            }
+            newTable[lastIdx] = lastRun;
+            // Clone all remaining nodes
+            for (HashEntry<K, V> p = e; p != lastRun; p = p.next) {
+              // Skip GC'd weak references
+              K key = p.key();
+              if (key == null) {
+                reduce++;
+                continue;
+              }
+              int k = p.hash & sizeMask;
+              HashEntry<K, V> n = newTable[k];
+              newTable[k] = newHashEntry(key, p.hash, n, p.value());
+            }
+          }
+        }
+      }
+      table = newTable;
+      Arrays.fill(oldTable, null);
+      return reduce;
+    }
+
+    /**
+     * Remove; match on key only if value null, else match both.
+     */
+    V remove(Object key, int hash, Object value, boolean refRemove) {
+      lock();
+      try {
+        int c = count - 1;
+        HashEntry<K, V>[] tab = table;
+        int index = hash & tab.length - 1;
+        HashEntry<K, V> first = tab[index];
+        HashEntry<K, V> e = first;
+        // a reference remove operation compares the Reference instance
+        while (e != null //
+            && key != e.key //
+            && (refRemove || hash != e.hash || !keyEq(key, e.key()))) {
+          e = e.next;
+        }
+
+        V oldValue = null;
+        if (e != null) {
+          V v = e.value();
+          if (value == null || value.equals(v)) {
+            oldValue = v;
+            // All entries following removed node can stay in list,
+            // but all preceding ones need to be cloned.
+            ++modCount;
+            HashEntry<K, V> newFirst = e.next;
+            for (HashEntry<K, V> p = first; p != e; p = p.next) {
+              K pKey = p.key();
+              if (pKey == null) { // Skip GC'd keys
+                c--;
+                continue;
+              }
+
+              newFirst = newHashEntry(pKey, p.hash, newFirst, p.value());
+            }
+            tab[index] = newFirst;
+            count = c; // write-volatile
+          }
+        }
+        return oldValue;
+      } finally {
+        unlock();
+      }
+    }
+
+    void clear() {
+      if (count != 0) {
+        lock();
+        try {
+          HashEntry<K, V>[] tab = table;
+          for (int i = 0; i < tab.length; i++) {
+            tab[i] = null;
+          }
+          ++modCount;
+          count = 0; // write-volatile
+        } finally {
+          unlock();
+        }
+      }
+    }
+  }
+
+    /* ---------------- Public operations -------------- */
+
+  /**
+   * Creates a new, empty map with the specified initial capacity, load factor
+   * and concurrency level.
+   *
+   * @param initialCapacity the initial capacity. The implementation performs
+   * internal sizing to accommodate this many elements.
+   * @param loadFactor the load factor threshold, used to control resizing.
+   * Resizing may be performed when the average number of
+   * elements per bin exceeds this threshold.
+   * @param concurrencyLevel the estimated number of concurrently updating
+   * threads. The implementation performs internal
+   * sizing to try to accommodate this many threads.
+   * @throws IllegalArgumentException if the initial capacity is negative or
+   * the load factor or concurrencyLevel are
+   * nonpositive.
+   */
+  public ConcurrentIdentityHashMap(int initialCapacity, float loadFactor, int concurrencyLevel) {
+    if (!(loadFactor > 0) || initialCapacity < 0 || concurrencyLevel <= 0) {
+      throw new IllegalArgumentException();
+    }
+
+    if (concurrencyLevel > MAX_SEGMENTS) {
+      concurrencyLevel = MAX_SEGMENTS;
+    }
+
+    // Find power-of-two sizes best matching arguments
+    int sshift = 0;
+    int ssize = 1;
+    while (ssize < concurrencyLevel) {
+      ++sshift;
+      ssize <<= 1;
+    }
+    segmentShift = 32 - sshift;
+    segmentMask = ssize - 1;
+    segments = Segment.newArray(ssize);
+
+    if (initialCapacity > MAXIMUM_CAPACITY) {
+      initialCapacity = MAXIMUM_CAPACITY;
+    }
+    int c = initialCapacity / ssize;
+    if (c * ssize < initialCapacity) {
+      ++c;
+    }
+    int cap = 1;
+    while (cap < c) {
+      cap <<= 1;
+    }
+
+    for (int i = 0; i < segments.length; ++i) {
+      segments[i] = new Segment<K, V>(cap, loadFactor);
+    }
+  }
+
+  /**
+   * Creates a new, empty map with the specified initial capacity and load
+   * factor and with the default reference types (weak keys, strong values),
+   * and concurrencyLevel (16).
+   *
+   * @param initialCapacity The implementation performs internal sizing to
+   * accommodate this many elements.
+   * @param loadFactor the load factor threshold, used to control resizing.
+   * Resizing may be performed when the average number of
+   * elements per bin exceeds this threshold.
+   * @throws IllegalArgumentException if the initial capacity of elements is
+   * negative or the load factor is
+   * nonpositive
+   */
+  public ConcurrentIdentityHashMap(int initialCapacity, float loadFactor) {
+    this(initialCapacity, loadFactor, DEFAULT_CONCURRENCY_LEVEL);
+  }
+
+  /**
+   * Creates a new, empty map with the specified initial capacity, and with
+   * default reference types (weak keys, strong values), load factor (0.75)
+   * and concurrencyLevel (16).
+   *
+   * @param initialCapacity the initial capacity. The implementation performs
+   * internal sizing to accommodate this many elements.
+   * @throws IllegalArgumentException if the initial capacity of elements is
+   * negative.
+   */
+  public ConcurrentIdentityHashMap(int initialCapacity) {
+    this(initialCapacity, DEFAULT_LOAD_FACTOR, DEFAULT_CONCURRENCY_LEVEL);
+  }
+
+  /**
+   * Creates a new, empty map with a default initial capacity (16), reference
+   * types (weak keys, strong values), default load factor (0.75) and
+   * concurrencyLevel (16).
+   */
+  public ConcurrentIdentityHashMap() {
+    this(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR, DEFAULT_CONCURRENCY_LEVEL);
+  }
+
+  /**
+   * Creates a new map with the same mappings as the given map. The map is
+   * created with a capacity of 1.5 times the number of mappings in the given
+   * map or 16 (whichever is greater), and a default load factor (0.75) and
+   * concurrencyLevel (16).
+   *
+   * @param m the map
+   */
+  public ConcurrentIdentityHashMap(Map<? extends K, ? extends V> m) {
+    this(Math.max((int) (m.size() / DEFAULT_LOAD_FACTOR) + 1, DEFAULT_INITIAL_CAPACITY), DEFAULT_LOAD_FACTOR, DEFAULT_CONCURRENCY_LEVEL);
+    putAll(m);
+  }
+
+  /**
+   * Returns <tt>true</tt> if this map contains no key-value mappings.
+   *
+   * @return <tt>true</tt> if this map contains no key-value mappings
+   */
+  @Override
+  public boolean isEmpty() {
+    final Segment<K, V>[] segments = this.segments;
+        /*
+         * We keep track of per-segment modCounts to avoid ABA problems in which
+         * an element in one segment was added and in another removed during
+         * traversal, in which case the table was never actually empty at any
+         * point. Note the similar use of modCounts in the size() and
+         * containsValue() methods, which are the only other methods also
+         * susceptible to ABA problems.
+         */
+    int[] mc = new int[segments.length];
+    int mcsum = 0;
+    for (int i = 0; i < segments.length; ++i) {
+      if (segments[i].count != 0) {
+        return false;
+      } else {
+        mcsum += mc[i] = segments[i].modCount;
+      }
+    }
+    // If mcsum happens to be zero, then we know we got a snapshot before
+    // any modifications at all were made.  This is probably common enough
+    // to bother tracking.
+    if (mcsum != 0) {
+      for (int i = 0; i < segments.length; ++i) {
+        if (segments[i].count != 0 || mc[i] != segments[i].modCount) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns the number of key-value mappings in this map. If the map contains
+   * more than <tt>Integer.MAX_VALUE</tt> elements, returns
+   * <tt>Integer.MAX_VALUE</tt>.
+   *
+   * @return the number of key-value mappings in this map
+   */
+  @Override
+  public int size() {
+    final Segment<K, V>[] segments = this.segments;
+    long sum = 0;
+    long check = 0;
+    int[] mc = new int[segments.length];
+    // Try a few times to get accurate count. On failure due to continuous
+    // async changes in table, resort to locking.
+    for (int k = 0; k < RETRIES_BEFORE_LOCK; ++k) {
+      check = 0;
+      sum = 0;
+      int mcsum = 0;
+      for (int i = 0; i < segments.length; ++i) {
+        sum += segments[i].count;
+        mcsum += mc[i] = segments[i].modCount;
+      }
+      if (mcsum != 0) {
+        for (int i = 0; i < segments.length; ++i) {
+          check += segments[i].count;
+          if (mc[i] != segments[i].modCount) {
+            check = -1; // force retry
+            break;
+          }
+        }
+      }
+      if (check == sum) {
+        break;
+      }
+    }
+    if (check != sum) { // Resort to locking all segments
+      sum = 0;
+      for (Segment<K, V> segment : segments) {
+        segment.lock();
+      }
+      for (Segment<K, V> segment : segments) {
+        sum += segment.count;
+      }
+      for (Segment<K, V> segment : segments) {
+        segment.unlock();
+      }
+    }
+    if (sum > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    } else {
+      return (int) sum;
+    }
+  }
+
+  /**
+   * Returns the value to which the specified key is mapped, or {@code null}
+   * if this map contains no mapping for the key.
+   *
+   * <p>More formally, if this map contains a mapping from a key {@code k} to
+   * a value {@code v} such that {@code key.equals(k)}, then this method
+   * returns {@code v}; otherwise it returns {@code null}.  (There can be at
+   * most one such mapping.)
+   *
+   * @throws NullPointerException if the specified key is null
+   */
+  @Override
+  public V get(Object key) {
+    int hash = hashOf(key);
+    return segmentFor(hash).get(key, hash);
+  }
+
+  /**
+   * Tests if the specified object is a key in this table.
+   *
+   * @param key possible key
+   * @return <tt>true</tt> if and only if the specified object is a key in
+   * this table, as determined by the <tt>equals</tt> method;
+   * <tt>false</tt> otherwise.
+   */
+  @Override
+  public boolean containsKey(Object key) {
+    int hash = hashOf(key);
+    return segmentFor(hash).containsKey(key, hash);
+  }
+
+  /**
+   * Returns <tt>true</tt> if this map maps one or more keys to the specified
+   * value. Note: This method requires a full internal traversal of the hash
+   * table, and so is much slower than method <tt>containsKey</tt>.
+   *
+   * @param value value whose presence in this map is to be tested
+   * @return <tt>true</tt> if this map maps one or more keys to the specified
+   * value
+   * @throws NullPointerException if the specified value is null
+   */
+
+  @Override
+  public boolean containsValue(Object value) {
+    if (value == null) {
+      throw new NullPointerException();
+    }
+
+    // See explanation of modCount use above
+
+    final Segment<K, V>[] segments = this.segments;
+    int[] mc = new int[segments.length];
+
+    // Try a few times without locking
+    for (int k = 0; k < RETRIES_BEFORE_LOCK; ++k) {
+      int mcsum = 0;
+      for (int i = 0; i < segments.length; ++i) {
+        mcsum += mc[i] = segments[i].modCount;
+        if (segments[i].containsValue(value)) {
+          return true;
+        }
+      }
+      boolean cleanSweep = true;
+      if (mcsum != 0) {
+        for (int i = 0; i < segments.length; ++i) {
+          if (mc[i] != segments[i].modCount) {
+            cleanSweep = false;
+            break;
+          }
+        }
+      }
+      if (cleanSweep) {
+        return false;
+      }
+    }
+    // Resort to locking all segments
+    for (Segment<K, V> segment : segments) {
+      segment.lock();
+    }
+    boolean found = false;
+    try {
+      for (Segment<K, V> segment : segments) {
+        if (segment.containsValue(value)) {
+          found = true;
+          break;
+        }
+      }
+    } finally {
+      for (Segment<K, V> segment : segments) {
+        segment.unlock();
+      }
+    }
+    return found;
+  }
+
+  /**
+   * Legacy method testing if some key maps into the specified value in this
+   * table.  This method is identical in functionality to
+   * {@link #containsValue}, and exists solely to ensure full compatibility
+   * with class {@link Hashtable}, which supported this method prior to
+   * introduction of the Java Collections framework.
+   *
+   * @param value a value to search for
+   * @return <tt>true</tt> if and only if some key maps to the <tt>value</tt>
+   * argument in this table as determined by the <tt>equals</tt>
+   * method; <tt>false</tt> otherwise
+   * @throws NullPointerException if the specified value is null
+   */
+  public boolean contains(Object value) {
+    return containsValue(value);
+  }
+
+  /**
+   * Maps the specified key to the specified value in this table.  Neither the
+   * key nor the value can be null.
+   *
+   * <p>The value can be retrieved by calling the <tt>get</tt> method with a
+   * key that is equal to the original key.
+   *
+   * @param key key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @return the previous value associated with <tt>key</tt>, or <tt>null</tt>
+   * if there was no mapping for <tt>key</tt>
+   * @throws NullPointerException if the specified key or value is null
+   */
+  @Override
+  public V put(K key, V value) {
+    if (value == null) {
+      throw new NullPointerException();
+    }
+    int hash = hashOf(key);
+    return segmentFor(hash).put(key, hash, value, false);
+  }
+
+  /**
+   * @return the previous value associated with the specified key, or
+   * <tt>null</tt> if there was no mapping for the key
+   */
+  public V putIfAbsent(K key, V value) {
+    if (value == null) {
+      throw new NullPointerException();
+    }
+    int hash = hashOf(key);
+    return segmentFor(hash).put(key, hash, value, true);
+  }
+
+  /**
+   * Copies all of the mappings from the specified map to this one.  These
+   * mappings replace any mappings that this map had for any of the keys
+   * currently in the specified map.
+   *
+   * @param m mappings to be stored in this map
+   */
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
+      put(e.getKey(), e.getValue());
+    }
+  }
+
+  /**
+   * Removes the key (and its corresponding value) from this map.  This method
+   * does nothing if the key is not in the map.
+   *
+   * @param key the key that needs to be removed
+   * @return the previous value associated with <tt>key</tt>, or <tt>null</tt>
+   * if there was no mapping for <tt>key</tt>
+   */
+  @Override
+  public V remove(Object key) {
+    int hash = hashOf(key);
+    return segmentFor(hash).remove(key, hash, null, false);
+  }
+
+  /**
+   * @throws NullPointerException if the specified key is null
+   */
+  public boolean remove(Object key, Object value) {
+    int hash = hashOf(key);
+    if (value == null) {
+      return false;
+    }
+    return segmentFor(hash).remove(key, hash, value, false) != null;
+  }
+
+  /**
+   * @throws NullPointerException if any of the arguments are null
+   */
+  public boolean replace(K key, V oldValue, V newValue) {
+    if (oldValue == null || newValue == null) {
+      throw new NullPointerException();
+    }
+    int hash = hashOf(key);
+    return segmentFor(hash).replace(key, hash, oldValue, newValue);
+  }
+
+  /**
+   * @return the previous value associated with the specified key, or
+   * <tt>null</tt> if there was no mapping for the key
+   * @throws NullPointerException if the specified key or value is null
+   */
+  public V replace(K key, V value) {
+    if (value == null) {
+      throw new NullPointerException();
+    }
+    int hash = hashOf(key);
+    return segmentFor(hash).replace(key, hash, value);
+  }
+
+  /**
+   * Removes all of the mappings from this map.
+   */
+  @Override
+  public void clear() {
+    for (Segment<K, V> segment : segments) {
+      segment.clear();
+    }
+  }
+
+  /**
+   * Returns a {@link Set} view of the keys contained in this map.  The set is
+   * backed by the map, so changes to the map are reflected in the set, and
+   * vice-versa.  The set supports element removal, which removes the
+   * corresponding mapping from this map, via the <tt>Iterator.remove</tt>,
+   * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt>, and
+   * <tt>clear</tt> operations.  It does not support the <tt>add</tt> or
+   * <tt>addAll</tt> operations.
+   *
+   * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that
+   * will never throw {@link ConcurrentModificationException}, and guarantees
+   * to traverse elements as they existed upon construction of the iterator,
+   * and may (but is not guaranteed to) reflect any modifications subsequent
+   * to construction.
+   */
+  @Override
+  public Set<K> keySet() {
+    Set<K> ks = keySet;
+    return ks != null ? ks : (keySet = new KeySet());
+  }
+
+  /**
+   * Returns a {@link Collection} view of the values contained in this map.
+   * The collection is backed by the map, so changes to the map are reflected
+   * in the collection, and vice-versa.  The collection supports element
+   * removal, which removes the corresponding mapping from this map, via the
+   * <tt>Iterator.remove</tt>, <tt>Collection.remove</tt>, <tt>removeAll</tt>,
+   * <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not support
+   * the <tt>add</tt> or <tt>addAll</tt> operations.
+   *
+   * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that
+   * will never throw {@link ConcurrentModificationException}, and guarantees
+   * to traverse elements as they existed upon construction of the iterator,
+   * and may (but is not guaranteed to) reflect any modifications subsequent
+   * to construction.
+   */
+  @Override
+  public Collection<V> values() {
+    Collection<V> vs = values;
+    return vs != null ? vs : (values = new Values());
+  }
+
+  /**
+   * Returns a {@link Set} view of the mappings contained in this map.
+   * The set is backed by the map, so changes to the map are reflected in the
+   * set, and vice-versa.  The set supports element removal, which removes the
+   * corresponding mapping from the map, via the <tt>Iterator.remove</tt>,
+   * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt>, and
+   * <tt>clear</tt> operations.  It does not support the <tt>add</tt> or
+   * <tt>addAll</tt> operations.
+   *
+   * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator that
+   * will never throw {@link ConcurrentModificationException}, and guarantees
+   * to traverse elements as they existed upon construction of the iterator,
+   * and may (but is not guaranteed to) reflect any modifications subsequent
+   * to construction.
+   */
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    Set<Map.Entry<K, V>> es = entrySet;
+    return es != null ? es : (entrySet = new EntrySet());
+  }
+
+  /**
+   * Returns an enumeration of the keys in this table.
+   *
+   * @return an enumeration of the keys in this table
+   * @see #keySet()
+   */
+  public Enumeration<K> keys() {
+    return new KeyIterator();
+  }
+
+  /**
+   * Returns an enumeration of the values in this table.
+   *
+   * @return an enumeration of the values in this table
+   * @see #values()
+   */
+  public Enumeration<V> elements() {
+    return new ValueIterator();
+  }
+
+  /**
+   * Returns a shallow copy of this
+   * <tt>ConcurrentHashMap</tt> instance: the keys and
+   * values themselves are not cloned.
+   *
+   * @return a shallow copy of this map.
+   */
+  public Object clone() {
+    // We cannot call super.clone, since it would share final
+    // segments array, and there's no way to reassign finals.
+
+    float lf = segments[0].loadFactor;
+    int segs = segments.length;
+    int cap = (int) (size() / lf);
+    if (cap < segs) cap = segs;
+    ConcurrentIdentityHashMap<K, V> t = new ConcurrentIdentityHashMap<K, V>(cap, lf, segs);
+    t.putAll(this);
+    return t;
+  }
+    /* ---------------- Iterator Support -------------- */
+
+  abstract class HashIterator {
+    int nextSegmentIndex;
+    int nextTableIndex;
+    HashEntry<K, V>[] currentTable;
+    HashEntry<K, V> nextEntry;
+    HashEntry<K, V> lastReturned;
+    K currentKey; // Strong reference to weak key (prevents gc)
+
+    HashIterator() {
+      nextSegmentIndex = segments.length - 1;
+      nextTableIndex = -1;
+      advance();
+    }
+
+    public void rewind() {
+      nextSegmentIndex = segments.length - 1;
+      nextTableIndex = -1;
+      currentTable = null;
+      nextEntry = null;
+      lastReturned = null;
+      currentKey = null;
+      advance();
+    }
+
+    public boolean hasMoreElements() {
+      return hasNext();
+    }
+
+    final void advance() {
+      if (nextEntry != null && (nextEntry = nextEntry.next) != null) {
+        return;
+      }
+
+      while (nextTableIndex >= 0) {
+        if ((nextEntry = currentTable[nextTableIndex--]) != null) {
+          return;
+        }
+      }
+
+      while (nextSegmentIndex >= 0) {
+        Segment<K, V> seg = segments[nextSegmentIndex--];
+        if (seg.count != 0) {
+          currentTable = seg.table;
+          for (int j = currentTable.length - 1; j >= 0; --j) {
+            if ((nextEntry = currentTable[j]) != null) {
+              nextTableIndex = j - 1;
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    public boolean hasNext() {
+      while (nextEntry != null) {
+        if (nextEntry.key() != null) {
+          return true;
+        }
+        advance();
+      }
+
+      return false;
+    }
+
+    HashEntry<K, V> nextEntry() {
+      do {
+        if (nextEntry == null) {
+          throw new NoSuchElementException();
+        }
+
+        lastReturned = nextEntry;
+        currentKey = lastReturned.key();
+        advance();
+      } while (currentKey == null); // Skip GC'd keys
+
+      return lastReturned;
+    }
+
+    public void remove() {
+      if (lastReturned == null) {
+        throw new IllegalStateException();
+      }
+      ConcurrentIdentityHashMap.this.remove(currentKey);
+      lastReturned = null;
+    }
+  }
+
+  final class KeyIterator extends HashIterator implements ReusableIterator<K>, Enumeration<K> {
+
+    public K next() {
+      return nextEntry().key();
+    }
+
+    public K nextElement() {
+      return nextEntry().key();
+    }
+  }
+
+  final class ValueIterator extends HashIterator implements ReusableIterator<V>, Enumeration<V> {
+
+    public V next() {
+      return nextEntry().value();
+    }
+
+    public V nextElement() {
+      return nextEntry().value();
+    }
+  }
+
+  /*
+   * This class is needed for JDK5 compatibility.
+   */
+  static class SimpleEntry<K, V> implements Entry<K, V> {
+
+    private final K key;
+
+    private V value;
+
+    public SimpleEntry(K key, V value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    public SimpleEntry(Entry<? extends K, ? extends V> entry) {
+      key = entry.getKey();
+      value = entry.getValue();
+    }
+
+    public K getKey() {
+      return key;
+    }
+
+    public V getValue() {
+      return value;
+    }
+
+    public V setValue(V value) {
+      V oldValue = this.value;
+      this.value = value;
+      return oldValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof Map.Entry<?, ?>)) {
+        return false;
+      }
+      @SuppressWarnings("rawtypes") Map.Entry e = (Map.Entry) o;
+      return eq(key, e.getKey()) && eq(value, e.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+      return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
+    }
+
+    @Override
+    public String toString() {
+      return key + "=" + value;
+    }
+
+    private static boolean eq(Object o1, Object o2) {
+      return o1 == null ? o2 == null : o1.equals(o2);
+    }
+  }
+
+  /**
+   * Custom Entry class used by EntryIterator.next(), that relays setValue
+   * changes to the underlying map.
+   */
+  final class WriteThroughEntry extends SimpleEntry<K, V> {
+
+    WriteThroughEntry(K k, V v) {
+      super(k, v);
+    }
+
+    /**
+     * Set our entry's value and write through to the map. The value to
+     * return is somewhat arbitrary here. Since a WriteThroughEntry does not
+     * necessarily track asynchronous changes, the most recent "previous"
+     * value could be different from what we return (or could even have been
+     * removed in which case the put will re-establish). We do not and can
+     * not guarantee more.
+     */
+    @Override
+    public V setValue(V value) {
+
+      if (value == null) {
+        throw new NullPointerException();
+      }
+      V v = super.setValue(value);
+      put(getKey(), value);
+      return v;
+    }
+  }
+
+  final class EntryIterator extends HashIterator implements ReusableIterator<Entry<K, V>> {
+    public Map.Entry<K, V> next() {
+      HashEntry<K, V> e = nextEntry();
+      return new WriteThroughEntry(e.key(), e.value());
+    }
+  }
+
+  final class KeySet extends AbstractSet<K> {
+    @Override
+    public Iterator<K> iterator() {
+      return new KeyIterator();
+    }
+
+    @Override
+    public int size() {
+      return ConcurrentIdentityHashMap.this.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return ConcurrentIdentityHashMap.this.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return containsKey(o);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      return ConcurrentIdentityHashMap.this.remove(o) != null;
+    }
+
+    @Override
+    public void clear() {
+      ConcurrentIdentityHashMap.this.clear();
+    }
+  }
+
+  final class Values extends AbstractCollection<V> {
+    @Override
+    public Iterator<V> iterator() {
+      return new ValueIterator();
+    }
+
+    @Override
+    public int size() {
+      return ConcurrentIdentityHashMap.this.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return ConcurrentIdentityHashMap.this.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return containsValue(o);
+    }
+
+    @Override
+    public void clear() {
+      ConcurrentIdentityHashMap.this.clear();
+    }
+  }
+
+  final class EntrySet extends AbstractSet<Map.Entry<K, V>> {
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() {
+      return new EntryIterator();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      if (!(o instanceof Map.Entry<?, ?>)) {
+        return false;
+      }
+      Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+      V v = get(e.getKey());
+      return v != null && v.equals(e.getValue());
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      if (!(o instanceof Map.Entry<?, ?>)) {
+        return false;
+      }
+      Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+      return ConcurrentIdentityHashMap.this.remove(e.getKey(), e.getValue());
+    }
+
+    @Override
+    public int size() {
+      return ConcurrentIdentityHashMap.this.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return ConcurrentIdentityHashMap.this.isEmpty();
+    }
+
+    @Override
+    public void clear() {
+      ConcurrentIdentityHashMap.this.clear();
+    }
+  }
+}

--- a/toothpick-runtime/src/main/java/toothpick/util/ReusableIterator.java
+++ b/toothpick-runtime/src/main/java/toothpick/util/ReusableIterator.java
@@ -1,0 +1,23 @@
+
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package toothpick.util;
+
+import java.util.Iterator;
+
+public interface ReusableIterator<E> extends Iterator<E> {
+    void rewind();
+}

--- a/toothpick-runtime/src/test/java/toothpick/ScopeImplDumpTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ScopeImplDumpTest.java
@@ -28,7 +28,7 @@ public class ScopeImplDumpTest extends ToothPickBaseTest {
         + "Providers: \\[toothpick.Scope,toothpick.data.Foo\\].*"
         + "\\\\---child:\\d+.*"
         + "Providers:.*\\[toothpick.Scope\\].*"
-        + "UnScoped providers: \\[toothpick.data.Bar\\].*", Pattern.DOTALL);
+        + "Unbound providers: \\[toothpick.data.Bar\\].*", Pattern.DOTALL);
     assertThat(dump, MatchesPattern.matchesPattern(expected));
   }
 

--- a/toothpick-runtime/src/test/java/toothpick/ScopeImplTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ScopeImplTest.java
@@ -41,21 +41,19 @@ public class ScopeImplTest extends ToothPickBaseTest {
     assertThat(instance, notNullValue());
   }
 
-  @Test
-  public void installOverrideModules_shouldInstallOverrideBindingsAgain_whenCalledTwice() {
+  @Test(expected = IllegalStateException.class)
+  public void installTestModules_shoudFailToInstallTestsBindingsAgain_whenCalledTwice() {
     //GIVEN
     Foo testFoo = new Foo();
     Foo testFoo2 = new Foo();
     ScopeImpl scope = new ScopeImpl("");
     scope.installTestModules(new TestModule(testFoo));
-    scope.installTestModules(new TestModule(testFoo2));
-    scope.installModules(new ProdModule2());
 
     //WHEN
-    Foo instance = scope.getInstance(Foo.class);
+    scope.installTestModules(new TestModule(testFoo2));
 
     //THEN
-    assertThat(instance, sameInstance(testFoo2));
+    fail("Should throw an exception");
   }
 
   @Test

--- a/toothpick-runtime/src/test/java/toothpick/ToothPickTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothPickTest.java
@@ -57,7 +57,7 @@ public class ToothPickTest extends ToothPickBaseTest {
     //GIVEN
 
     //WHEN
-    Scope scope = ToothPick.openScopes(null);
+    ToothPick.openScopes((Object[]) null);
 
     //THEN
     fail("Shoudl ahve thrown an exception");

--- a/toothpick-runtime/src/test/java/toothpick/ToothPickVisibilityExposer.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothPickVisibilityExposer.java
@@ -1,0 +1,10 @@
+package toothpick;
+
+public class ToothPickVisibilityExposer {
+  private ToothPickVisibilityExposer() {
+  }
+
+  public static int getScopeNamesSize() {
+    return ToothPick.getScopeNamesSize();
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/BindingsMultiThreadTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/BindingsMultiThreadTest.java
@@ -1,0 +1,196 @@
+package toothpick.concurrency;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import toothpick.Factory;
+import toothpick.Scope;
+import toothpick.ToothPick;
+import toothpick.concurrency.threads.GetInstanceThread;
+import toothpick.concurrency.threads.InstallBindingThread;
+import toothpick.concurrency.threads.ScopeToStringThread;
+import toothpick.concurrency.threads.TestableThread;
+import toothpick.concurrency.utils.ClassCreator;
+import toothpick.concurrency.utils.ThreadTestUtil;
+import toothpick.registries.FactoryRegistry;
+import toothpick.registries.FactoryRegistryLocator;
+import toothpick.registries.MemberInjectorRegistryLocator;
+
+import static org.junit.Assert.assertTrue;
+import static toothpick.concurrency.utils.ThreadTestUtil.STANDARD_THREAD_COUNT;
+
+public class BindingsMultiThreadTest {
+
+  static final String ROOT_SCOPE = "ROOT_SCOPE";
+  final List<Object> scopeNames = new CopyOnWriteArrayList<>();
+  private static ClassCreator classCreator = new ClassCreator();
+
+  @Before
+  public void setUp() throws Exception {
+    ToothPick.openScope(ROOT_SCOPE);
+    scopeNames.clear();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    ToothPick.reset();
+    FactoryRegistryLocator.setRootRegistry(null);
+    MemberInjectorRegistryLocator.setRootRegistry(null);
+    ThreadTestUtil.shutdown();
+  }
+
+  @Test
+  public void concurrentBindingInstall_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount; indexThread++) {
+      InstallBindingThread runnable = new InstallBindingThread(classCreator, ROOT_SCOPE);
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentBindingInstallAndToString_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+    Random random = new Random();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount; indexThread++) {
+      TestableThread runnable;
+      if (random.nextInt(100) < 20) {
+        runnable = new InstallBindingThread(classCreator, ROOT_SCOPE);
+      } else {
+        runnable = new ScopeToStringThread(ROOT_SCOPE);
+      }
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentBindingInstallAndGetInstance_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+    Random random = new Random();
+    FactoryRegistryLocator.setRootRegistry(new DynamicTestClassesFactoryRegistry(true));
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount; indexThread++) {
+      TestableThread runnable;
+      if (random.nextInt(100) < 20) {
+        runnable = new InstallBindingThread(classCreator, ROOT_SCOPE);
+      } else {
+        runnable = new GetInstanceThread(ROOT_SCOPE, classCreator.allClasses[random.nextInt(classCreator.allClasses.length)]);
+      }
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    boolean timeout = ThreadTestUtil.shutdown();
+    assertTrue("Executor service should not timeout.", timeout);
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentScopedGetInstance_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+    Random random = new Random();
+    FactoryRegistryLocator.setRootRegistry(new DynamicTestClassesFactoryRegistry(true));
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount; indexThread++) {
+      TestableThread runnable = new GetInstanceThread(ROOT_SCOPE, classCreator.allClasses[random.nextInt(classCreator.allClasses.length)]);
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    boolean timeout = ThreadTestUtil.shutdown();
+    assertTrue("Executor service should not timeout.", timeout);
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  private static class DynamicTestClassesFactory<T> implements Factory<T> {
+    private final Class<T> clazz;
+    private boolean scoped;
+
+    public DynamicTestClassesFactory(Class<T> clazz, boolean scoped) {
+      this.clazz = clazz;
+      this.scoped = scoped;
+    }
+
+    @Override
+    public T createInstance(Scope scope) {
+      try {
+        return clazz.newInstance();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public Scope getTargetScope(Scope currentScope) {
+      return currentScope;
+    }
+
+    @Override
+    public boolean hasScopeAnnotation() {
+      return scoped;
+    }
+
+    @Override
+    public boolean hasScopeInstancesAnnotation() {
+      return false;
+    }
+  }
+
+  private static class DynamicTestClassesFactoryRegistry implements FactoryRegistry {
+    private boolean scoped;
+
+    public DynamicTestClassesFactoryRegistry(boolean scoped) {
+      this.scoped = scoped;
+    }
+
+    @Override
+    public <T> Factory<T> getFactory(final Class<T> clazz) {
+      if (clazz.getName().startsWith("Class_")) {
+        return new DynamicTestClassesFactory<>(clazz, scoped);
+      }
+      return null;
+    }
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/ScopeTreeManipulationsMultiThreadTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/ScopeTreeManipulationsMultiThreadTest.java
@@ -1,0 +1,101 @@
+package toothpick.concurrency;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import toothpick.ToothPick;
+import toothpick.concurrency.threads.AddNodeThread;
+import toothpick.concurrency.threads.RemoveNodeThread;
+import toothpick.concurrency.threads.TestableThread;
+import toothpick.concurrency.utils.ThreadTestUtil;
+
+import static org.junit.Assert.assertTrue;
+import static toothpick.concurrency.utils.ThreadTestUtil.STANDARD_THREAD_COUNT;
+
+public class ScopeTreeManipulationsMultiThreadTest {
+
+  static final String ROOT_SCOPE = "ROOT_SCOPE";
+
+  @Before
+  public void setUp() throws Exception {
+    ToothPick.openScope(ROOT_SCOPE);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    ToothPick.reset();
+  }
+
+  @Test
+  public void concurrentScopeAdditions_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount; indexThread++) {
+      AddNodeThread runnable = new AddNodeThread(ROOT_SCOPE);
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentScopeRemovals_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int removalNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < removalNodeThreadCount; indexThread++) {
+      RemoveNodeThread runnable = new RemoveNodeThread(ROOT_SCOPE);
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentScopeAdditionsAndRemovals_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int removalNodeThreadCount = STANDARD_THREAD_COUNT / 2;
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT / 2;
+    List<TestableThread> threadList = new ArrayList<>();
+    final Random random = new Random();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount + removalNodeThreadCount; indexThread++) {
+      final TestableThread runnable;
+      if (random.nextInt(100) < 50) {
+        runnable = new RemoveNodeThread(ROOT_SCOPE);
+      } else {
+        runnable = new AddNodeThread(ROOT_SCOPE);
+      }
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/ToothPickManipulationsMultiThreadTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/ToothPickManipulationsMultiThreadTest.java
@@ -1,0 +1,165 @@
+package toothpick.concurrency;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import toothpick.ToothPick;
+import toothpick.ToothPickVisibilityExposer;
+import toothpick.concurrency.threads.AddSameScopeThread;
+import toothpick.concurrency.threads.AddScopeToListThread;
+import toothpick.concurrency.threads.RemoveSameScopeThread;
+import toothpick.concurrency.threads.RemoveScopeFromListThread;
+import toothpick.concurrency.threads.TestableThread;
+import toothpick.concurrency.utils.ThreadTestUtil;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static toothpick.concurrency.utils.ThreadTestUtil.STANDARD_THREAD_COUNT;
+
+public class ToothPickManipulationsMultiThreadTest {
+
+  static final String ROOT_SCOPE = "ROOT_SCOPE";
+  final List<Object> scopeNames = new CopyOnWriteArrayList<>();
+
+  @Before
+  public void setUp() throws Exception {
+    ToothPick.openScope(ROOT_SCOPE);
+    scopeNames.clear();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    ToothPick.reset();
+  }
+
+  @Test
+  public void concurrentOpenScopes_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount; indexThread++) {
+      AddScopeToListThread runnable = new AddScopeToListThread(scopeNames);
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentCloseScopes_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int scopeCount = 100;
+    for (int indexScope = 0; indexScope < scopeCount; indexScope++) {
+      Object newScopeName = new Object();
+      scopeNames.add(newScopeName);
+      ToothPick.openScopes(ROOT_SCOPE, newScopeName);
+    }
+    final int removalNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < removalNodeThreadCount; indexThread++) {
+      RemoveScopeFromListThread runnable = new RemoveScopeFromListThread(scopeNames);
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentOpenAndCloseScopes_shouldNotCrash() throws InterruptedException {
+    //GIVEN
+    final int removalNodeThreadCount = STANDARD_THREAD_COUNT;
+    final int addNodeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+    final Random random = new Random();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addNodeThreadCount + removalNodeThreadCount; indexThread++) {
+      final TestableThread runnable;
+      if (random.nextInt(100) < 50) {
+        runnable = new RemoveScopeFromListThread(scopeNames);
+      } else {
+        runnable = new AddScopeToListThread(scopeNames);
+      }
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    //we simply should not have crashed when all threads are done
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+  }
+
+  @Test
+  public void concurrentOpenScopes_shouldAddChildScopeOnlyOnce_withSameChildScope() throws InterruptedException {
+    //GIVEN
+    final int addSameScopeThreadCount = STANDARD_THREAD_COUNT;
+    List<TestableThread> threadList = new ArrayList<>();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addSameScopeThreadCount; indexThread++) {
+      final TestableThread runnable = new AddSameScopeThread(ROOT_SCOPE, "childScope");
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+    assertThat(ToothPickVisibilityExposer.getScopeNamesSize(), is(2));
+  }
+
+  @Test
+  public void concurrentOpenScopes_shouldAddChildScopeAtMostOnce_withSameChildScope() throws InterruptedException {
+    //GIVEN
+    final int addSameScopeThreadCount = STANDARD_THREAD_COUNT / 2;
+    final int removeSameScopeThreadCount = STANDARD_THREAD_COUNT / 2;
+    List<TestableThread> threadList = new ArrayList<>();
+    final Random random = new Random();
+
+    //WHEN
+    for (int indexThread = 0; indexThread < addSameScopeThreadCount + removeSameScopeThreadCount; indexThread++) {
+      final TestableThread runnable;
+      if (random.nextInt(100) < 50) {
+        runnable = new RemoveSameScopeThread("childScope");
+      } else {
+        runnable = new AddSameScopeThread(ROOT_SCOPE, "childScope");
+      }
+      threadList.add(runnable);
+      ThreadTestUtil.submit(runnable);
+    }
+
+    //THEN
+    ThreadTestUtil.shutdown();
+    for (TestableThread thread : threadList) {
+      assertTrue(String.format("test of thread %s failed", thread.getName()), thread.isSuccessful());
+    }
+    assertThat(ToothPickVisibilityExposer.getScopeNamesSize(), anyOf(is(1), is(2)));
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/AddNodeThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/AddNodeThread.java
@@ -1,0 +1,30 @@
+package toothpick.concurrency.threads;
+
+import toothpick.Scope;
+import toothpick.ToothPick;
+import toothpick.concurrency.utils.ThreadTestUtil;
+
+public class AddNodeThread extends TestableThread {
+  static final int ACCEPTANCE_THRESHOLD = 50;
+  static int instanceNumber = 0;
+  private Object rootScopeName;
+
+  public AddNodeThread(Object rootScopeName) {
+    super("AddNodeThread " + instanceNumber++);
+    this.rootScopeName = rootScopeName;
+  }
+
+  @Override
+  public void doRun() {
+    //pick a random node in the tree, starting from root
+    //add a new child node to this node
+    Scope scopeName = ThreadTestUtil.findRandomNode(rootScopeName, ACCEPTANCE_THRESHOLD);
+    if (scopeName == null) {
+      setIsSuccessful(true);
+      return;
+    }
+    Object name = scopeName.getName();
+    ToothPick.openScopes(name, new Object());
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/AddSameScopeThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/AddSameScopeThread.java
@@ -1,0 +1,21 @@
+package toothpick.concurrency.threads;
+
+import toothpick.ToothPick;
+
+public class AddSameScopeThread extends TestableThread {
+  static int instanceNumber = 0;
+  private final Object parentScopeName;
+  private final Object childScopeName;
+
+  public AddSameScopeThread(Object parentScopeName, Object childScopeName) {
+    super("AddNodeThread " + instanceNumber++);
+    this.parentScopeName = parentScopeName;
+    this.childScopeName = childScopeName;
+  }
+
+  @Override
+  public void doRun() {
+    ToothPick.openScopes(parentScopeName, childScopeName);
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/AddScopeToListThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/AddScopeToListThread.java
@@ -1,0 +1,33 @@
+package toothpick.concurrency.threads;
+
+import java.util.List;
+import toothpick.Scope;
+import toothpick.ToothPick;
+import toothpick.concurrency.utils.ThreadTestUtil;
+
+public class AddScopeToListThread extends TestableThread {
+  static final int ACCEPTANCE_THRESHOLD = 50;
+  static int instanceNumber = 0;
+  private List<Object> scopeNames;
+
+  public AddScopeToListThread(List<Object> scopeNames) {
+    super("AddNodeThread " + instanceNumber++);
+    this.scopeNames = scopeNames;
+  }
+
+  @Override
+  public void doRun() {
+    //pick a random node in the tree, starting from root
+    //add a new child node to this node
+    Scope scopeName = ThreadTestUtil.findRandomNode(scopeNames, ACCEPTANCE_THRESHOLD);
+    if (scopeName == null) {
+      setIsSuccessful(true);
+      return;
+    }
+    Object name = scopeName.getName();
+    Object newScopeName = new Object();
+    scopeNames.add(newScopeName);
+    ToothPick.openScopes(name, newScopeName);
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/GetInstanceThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/GetInstanceThread.java
@@ -1,0 +1,21 @@
+package toothpick.concurrency.threads;
+
+import toothpick.ToothPick;
+
+public class GetInstanceThread extends TestableThread {
+  static int instanceNumber = 0;
+  private Object scopeName;
+  private Class clazz;
+
+  public GetInstanceThread(Object scopeName, Class clazz) {
+    super("GetInstanceThread " + instanceNumber++);
+    this.scopeName = scopeName;
+    this.clazz = clazz;
+  }
+
+  @Override
+  public void doRun() {
+    ToothPick.openScope(scopeName).getInstance(clazz);
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/InstallBindingThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/InstallBindingThread.java
@@ -1,0 +1,33 @@
+package toothpick.concurrency.threads;
+
+import java.util.Random;
+import toothpick.Scope;
+import toothpick.ToothPick;
+import toothpick.concurrency.utils.ClassCreator;
+import toothpick.config.Module;
+import toothpick.data.Foo;
+
+public class InstallBindingThread extends TestableThread {
+  static int instanceNumber = 0;
+  private ClassCreator classCreator;
+  private Object rootScopeName;
+  private static Random random = new Random();
+
+  public InstallBindingThread(ClassCreator classCreator, Object rootScopeName) {
+    super("InstallBindingThread " + instanceNumber++);
+    this.classCreator = classCreator;
+    this.rootScopeName = rootScopeName;
+  }
+
+  @Override
+  public void doRun() {
+    Scope scope = ToothPick.openScope(rootScopeName);
+    scope.installModules(new Module() {
+      {
+        Class clazz = classCreator.allClasses[random.nextInt(classCreator.allClasses.length)];
+        bind(clazz).to(new Foo());
+      }
+    });
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/RemoveNodeThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/RemoveNodeThread.java
@@ -1,0 +1,35 @@
+package toothpick.concurrency.threads;
+
+import toothpick.Scope;
+import toothpick.ToothPick;
+import toothpick.concurrency.utils.ThreadTestUtil;
+
+public class RemoveNodeThread extends TestableThread {
+  static final int ACCEPTANCE_THRESHOLD = 50;
+  static int instanceNumber = 0;
+  private Object rootScopeName;
+
+  public RemoveNodeThread(Object rootScopeName) {
+    super("RemoveNodeThread " + instanceNumber++);
+    this.rootScopeName = rootScopeName;
+  }
+
+  @Override
+  public void doRun() {
+    //pick a random node in the tree, starting from root
+    //add a new child node to this node
+    Scope scope = ThreadTestUtil.findRandomNode(rootScopeName, ACCEPTANCE_THRESHOLD);
+    if (scope == null) {
+      setIsSuccessful(true);
+      return;
+    }
+    //remove any node except root
+    if (scope.getParentScope() == null) {
+      setIsSuccessful(true);
+      return;
+    }
+    Object scopeName = scope.getName();
+    ToothPick.closeScope(scopeName);
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/RemoveSameScopeThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/RemoveSameScopeThread.java
@@ -1,0 +1,19 @@
+package toothpick.concurrency.threads;
+
+import toothpick.ToothPick;
+
+public class RemoveSameScopeThread extends TestableThread {
+  static int instanceNumber = 0;
+  private final Object childScopeName;
+
+  public RemoveSameScopeThread(Object childScopeName) {
+    super("RemoveNodeThread " + instanceNumber++);
+    this.childScopeName = childScopeName;
+  }
+
+  @Override
+  public void doRun() {
+    ToothPick.closeScope(childScopeName);
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/RemoveScopeFromListThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/RemoveScopeFromListThread.java
@@ -1,0 +1,36 @@
+package toothpick.concurrency.threads;
+
+import java.util.List;
+import toothpick.Scope;
+import toothpick.ToothPick;
+import toothpick.concurrency.utils.ThreadTestUtil;
+
+public class RemoveScopeFromListThread extends TestableThread {
+  static final int ACCEPTANCE_THRESHOLD = 50;
+  static int instanceNumber = 0;
+  private List<Object> scopeNames;
+
+  public RemoveScopeFromListThread(List<Object> scopeNames) {
+    super("RemoveNodeThread " + instanceNumber++);
+    this.scopeNames = scopeNames;
+  }
+
+  @Override
+  public void doRun() {
+    //pick a random node in the tree, starting from root
+    //add a new child node to this node
+    Scope scope = ThreadTestUtil.findRandomNode(scopeNames, ACCEPTANCE_THRESHOLD);
+    if (scope == null) {
+      setIsSuccessful(true);
+      return;
+    }
+    //remove any node except root
+    if (scope.getParentScope() == null) {
+      setIsSuccessful(true);
+      return;
+    }
+    Object scopeName = scope.getName();
+    ToothPick.closeScope(scopeName);
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/ScopeToStringThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/ScopeToStringThread.java
@@ -1,0 +1,21 @@
+package toothpick.concurrency.threads;
+
+import java.util.Random;
+import toothpick.ToothPick;
+
+public class ScopeToStringThread extends TestableThread {
+  static int instanceNumber = 0;
+  private Object scopeName;
+  private static Random random = new Random();
+
+  public ScopeToStringThread(Object scopeName) {
+    super("ScopeToStringThread " + instanceNumber++);
+    this.scopeName = scopeName;
+  }
+
+  @Override
+  public void doRun() {
+    ToothPick.openScope(scopeName).toString();
+    setIsSuccessful(true);
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/threads/TestableThread.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/threads/TestableThread.java
@@ -1,0 +1,41 @@
+package toothpick.concurrency.threads;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.lang.String.format;
+import static toothpick.concurrency.utils.TestUtil.log;
+
+public abstract class TestableThread implements Runnable {
+  protected AtomicBoolean isSuccessful = new AtomicBoolean(false);
+  private String name;
+
+  public TestableThread(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public final void run() {
+    log(format("Thread %s starting", name));
+    try {
+      doRun();
+    } catch (Exception e) {
+      System.err.println(format("Thread %s crashed", name));
+      e.printStackTrace();
+    }
+    log(format("Thread %s finished", name));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  protected abstract void doRun();
+
+  protected void setIsSuccessful(boolean b) {
+    isSuccessful.set(b);
+  }
+
+  public boolean isSuccessful() {
+    return isSuccessful.get();
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/utils/ClassCreator.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/utils/ClassCreator.java
@@ -1,0 +1,110 @@
+package toothpick.concurrency.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+//from http://stackoverflow.com/a/2320465/693752
+
+/**
+ * We create classes dynamically with this class.
+ * It can seem a bit far fetched. We could also have enumerated a thousand real classes
+ * from the JDK or create them by hand for real. But this is more scalable and allow more testing.
+ * We also have full control on the classes.
+ *
+ * They are used as injection parameters and bindings.
+ */
+public class ClassCreator {
+  private ByteClassLoader byteClassLoader = new ByteClassLoader(ClassCreator.class.getClassLoader());
+  private final static int CLASSES_COUNT = 1000;
+
+  public Class[] allClasses;
+
+  public ClassCreator() {
+    try {
+      allClasses = createClasses();
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException("Impossible to create all classes.", e);
+    }
+  }
+
+  private Class[] createClasses() throws ClassNotFoundException, IOException {
+    Map<String, String> mapClassNameToJavaSource = new HashMap<>();
+    for (int indexClass = 0; indexClass < CLASSES_COUNT; indexClass++) {
+      String className = "Class_" + indexClass;
+      String source = String.format("public class %s {}\n", className, className);
+      mapClassNameToJavaSource.put(className, source);
+    }
+    List<Class> classes = new ArrayList<>();
+    Map<String, byte[]> buffers = compile(mapClassNameToJavaSource);
+    for (Map.Entry<String, byte[]> classNameToByteCodeEntry : buffers.entrySet()) {
+      String className = classNameToByteCodeEntry.getKey();
+      byte[] buffer = classNameToByteCodeEntry.getValue();
+      Class clazz = byteClassLoader.defineClass(className, buffer);
+      classes.add(clazz);
+    }
+
+    return classes.toArray(new Class[0]);
+  }
+
+  private Map<String, byte[]> compile(Map<String, String> mapClassNameToJavaSource) {
+    DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    InMemoryJavaFileManager fileManager = new InMemoryJavaFileManager(compiler.getStandardFileManager(diagnostics, null, null));
+
+    List<JavaFileObject> compilationUnit = new ArrayList<>();
+    for (Map.Entry<String, String> classNameToSourceEntry : mapClassNameToJavaSource.entrySet()) {
+      JavaFileObject source = new JavaSourceFromString(classNameToSourceEntry.getKey(), classNameToSourceEntry.getValue());
+      compilationUnit.add(source);
+    }
+
+    JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnit);
+    if (!task.call()) {
+      for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
+        System.out.format("Error on line %d in %s%n", diagnostic.getLineNumber(), diagnostic.getSource());
+      }
+      return null;
+    }
+    return fileManager.getAllBuffers();
+  }
+
+  public static class ByteClassLoader extends URLClassLoader {
+
+    public ByteClassLoader(ClassLoader parent) {
+      super(new URL[0], parent);
+    }
+
+    public Class<?> defineClass(final String name, byte[] classBytes) throws ClassNotFoundException {
+      if (classBytes != null) {
+        return defineClass(name, classBytes, 0, classBytes.length);
+      }
+      return null;
+    }
+  }
+
+  class JavaSourceFromString extends SimpleJavaFileObject {
+    final String code;
+
+    JavaSourceFromString(String name, String code) {
+      super(URI.create("string:///" + name.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
+      this.code = code;
+    }
+
+    @Override
+    public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+      return code;
+    }
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/utils/InMemoryJavaFileManager.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/utils/InMemoryJavaFileManager.java
@@ -1,0 +1,107 @@
+package toothpick.concurrency.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+
+//from https://github.com/OpenHFT/Java-Runtime-Compiler/blob/master/compiler/src/main/java/net/openhft/compiler/CachedCompiler.java
+public class InMemoryJavaFileManager implements JavaFileManager {
+  private final StandardJavaFileManager fileManager;
+  private final Map<String, ByteArrayOutputStream> buffers = new LinkedHashMap<String, ByteArrayOutputStream>();
+
+  InMemoryJavaFileManager(StandardJavaFileManager fileManager) {
+    this.fileManager = fileManager;
+  }
+
+  public ClassLoader getClassLoader(Location location) {
+    return fileManager.getClassLoader(location);
+  }
+
+  public Iterable<JavaFileObject> list(Location location, String packageName, Set<Kind> kinds, boolean recurse) throws IOException {
+    return fileManager.list(location, packageName, kinds, recurse);
+  }
+
+  public String inferBinaryName(Location location, JavaFileObject file) {
+    return fileManager.inferBinaryName(location, file);
+  }
+
+  public boolean isSameFile(FileObject a, FileObject b) {
+    return fileManager.isSameFile(a, b);
+  }
+
+  public boolean handleOption(String current, Iterator<String> remaining) {
+    return fileManager.handleOption(current, remaining);
+  }
+
+  public boolean hasLocation(Location location) {
+    return fileManager.hasLocation(location);
+  }
+
+  public JavaFileObject getJavaFileForInput(Location location, String className, Kind kind) throws IOException {
+    if (location == StandardLocation.CLASS_OUTPUT && buffers.containsKey(className) && kind == Kind.CLASS) {
+      final byte[] bytes = buffers.get(className).toByteArray();
+      return new SimpleJavaFileObject(URI.create(className), kind) {
+        public InputStream openInputStream() {
+          return new ByteArrayInputStream(bytes);
+        }
+      };
+    }
+    return fileManager.getJavaFileForInput(location, className, kind);
+  }
+
+  public JavaFileObject getJavaFileForOutput(Location location, final String className, Kind kind, FileObject sibling) throws IOException {
+    return new SimpleJavaFileObject(URI.create(className), kind) {
+      public OutputStream openOutputStream() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        buffers.put(className, baos);
+        return baos;
+      }
+    };
+  }
+
+  public FileObject getFileForInput(Location location, String packageName, String relativeName) throws IOException {
+    return fileManager.getFileForInput(location, packageName, relativeName);
+  }
+
+  public FileObject getFileForOutput(Location location, String packageName, String relativeName, FileObject sibling) throws IOException {
+    return fileManager.getFileForOutput(location, packageName, relativeName, sibling);
+  }
+
+  public void flush() throws IOException {
+    // Do nothing
+  }
+
+  public void close() throws IOException {
+    fileManager.close();
+  }
+
+  public int isSupportedOption(String option) {
+    return fileManager.isSupportedOption(option);
+  }
+
+  public void clearBuffers() {
+    buffers.clear();
+  }
+
+  public Map<String, byte[]> getAllBuffers() {
+    Map<String, byte[]> ret = new LinkedHashMap<String, byte[]>(buffers.size() * 2);
+    for (Map.Entry<String, ByteArrayOutputStream> entry : buffers.entrySet()) {
+      ret.put(entry.getKey(), entry.getValue().toByteArray());
+    }
+    return ret;
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/utils/TestUtil.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/utils/TestUtil.java
@@ -1,0 +1,15 @@
+package toothpick.concurrency.utils;
+
+public class TestUtil {
+
+  public final static boolean DEBUG = false;
+
+  private TestUtil() {
+  }
+
+  public static void log(String s) {
+    if (DEBUG) {
+      System.out.println(s);
+    }
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/utils/ThreadTestUtil.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/utils/ThreadTestUtil.java
@@ -1,0 +1,68 @@
+package toothpick.concurrency.utils;
+
+import java.util.List;
+import java.util.Random;
+import java.util.Stack;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import toothpick.Scope;
+import toothpick.ToothPick;
+
+public class ThreadTestUtil {
+  private static final Random RANDOM = new Random();
+  private static final int RANDOM_INTERVAL_LENGTH = 100;
+  public static final int STANDARD_THREAD_COUNT = 10000;
+  static ExecutorService executorService = Executors.newFixedThreadPool(6);
+
+  private ThreadTestUtil() {
+  }
+
+  public static void submit(Runnable runnable) {
+    executorService.submit(runnable);
+  }
+
+  public static boolean shutdown() {
+    try {
+      executorService.shutdown();
+      return executorService.awaitTermination(STANDARD_THREAD_COUNT / 100, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+      return true;
+    } finally {
+      executorService = Executors.newFixedThreadPool(6);
+    }
+  }
+
+  public static Scope findRandomNode(Object rooScopeName, int acceptanceThreshold) {
+    Scope root = ToothPick.openScope(rooScopeName);
+    Scope result = null;
+    Stack<Scope> scopeStack = new Stack<Scope>();
+    scopeStack.push(root);
+    while (result == null && !scopeStack.isEmpty()) {
+      Scope scope = scopeStack.pop();
+      if (RANDOM.nextInt(RANDOM_INTERVAL_LENGTH) < acceptanceThreshold && scope != root) {
+        result = scope;
+      } else {
+        for (Scope childScope : scope.getChildrenScopes()) {
+          scopeStack.push(childScope);
+        }
+      }
+    }
+    return result;
+  }
+
+  public static Scope findRandomNode(List<Object> scopeNames, int acceptanceThreshold) {
+    if (RANDOM.nextInt(RANDOM_INTERVAL_LENGTH) < acceptanceThreshold) {
+      return null;
+    } else {
+      synchronized (scopeNames) {
+        if (scopeNames.isEmpty()) {
+          return null;
+        }
+        int position = RANDOM.nextInt(scopeNames.size());
+        return ToothPick.openScope(scopeNames.get(position));
+      }
+    }
+  }
+}

--- a/toothpick-runtime/src/test/java/toothpick/getInstance/CycleCheckTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/getInstance/CycleCheckTest.java
@@ -24,6 +24,7 @@ public class CycleCheckTest extends ToothPickBaseTest {
   public static void setUp() throws Exception {
     ToothPickBaseTest.setUp();
     ToothPick.setConfiguration(development());
+    ToothPickBaseTest.setUp();
   }
 
   @AfterClass

--- a/toothpick-runtime/src/test/java/toothpick/scoping/ScopingTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/scoping/ScopingTest.java
@@ -169,8 +169,8 @@ public class ScopingTest extends ToothPickBaseTest {
   public void singleton_shouldBeSharedBySubscopes() throws Exception {
     //GIVEN
     Scope scopeParent = new ScopeImpl("");
-    Scope scope1 = new ScopeImpl("");
-    Scope scope2 = new ScopeImpl("");
+    Scope scope1 = new ScopeImpl("scope1");
+    Scope scope2 = new ScopeImpl("scope2");
     scopeParent.addChild(scope1);
     scopeParent.addChild(scope2);
 
@@ -187,8 +187,8 @@ public class ScopingTest extends ToothPickBaseTest {
     //GIVEN
     ToothPick.setConfiguration(development());
     Scope scopeParent = new ScopeImpl("");
-    Scope scope1 = new ScopeImpl("");
-    Scope scope2 = new ScopeImpl("");
+    Scope scope1 = new ScopeImpl("scope1");
+    Scope scope2 = new ScopeImpl("scope2");
     scopeParent.addChild(scope1);
     scopeParent.addChild(scope2);
 
@@ -208,8 +208,8 @@ public class ScopingTest extends ToothPickBaseTest {
     //GIVEN
     ToothPick.setConfiguration(development());
     Scope scopeParent = new ScopeImpl("");
-    Scope scope1 = new ScopeImpl("");
-    Scope scope2 = new ScopeImpl("");
+    Scope scope1 = new ScopeImpl("scope1");
+    Scope scope2 = new ScopeImpl("scope2");
     scopeParent.addChild(scope1);
     scopeParent.addChild(scope2);
 

--- a/toothpick-runtime/src/test/java/toothpick/util/ConcurrentIdentityHashMapTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/util/ConcurrentIdentityHashMapTest.java
@@ -1,0 +1,578 @@
+package toothpick.util;
+
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/licenses/publicdomain
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ConcurrentIdentityHashMapTest {
+  static final Integer ZERO = new Integer(0);
+  static final Integer ONE = new Integer(1);
+  static final Integer TWO = new Integer(2);
+  static final Integer THREE = new Integer(3);
+  static final Integer FOUR = new Integer(4);
+  static final Integer FIVE = new Integer(5);
+  static final Integer SIX = new Integer(6);
+  public static long shortDelayMs;
+  public static long smallDelayMs;
+  public static long mediumDelayMs;
+  public static long longDelayMs;
+  /**
+   * Flag set true if any threadAssert methods fail
+   */
+  volatile boolean threadFailed;
+
+  /**
+   * Create a map from Integers 1-5 to Strings "A"-"E".
+   */
+  private static ConcurrentIdentityHashMap map5() {
+    ConcurrentIdentityHashMap map = new ConcurrentIdentityHashMap(5);
+    assertTrue(map.isEmpty());
+    map.put(ONE, "A");
+    map.put(TWO, "B");
+    map.put(THREE, "C");
+    map.put(FOUR, "D");
+    map.put(FIVE, "E");
+    assertFalse(map.isEmpty());
+    assertEquals(5, map.size());
+    return map;
+  }
+
+  /**
+   * clear removes all pairs
+   */
+  @Test
+  public void testClear() {
+    ConcurrentIdentityHashMap map = map5();
+    map.clear();
+    assertEquals(map.size(), 0);
+  }
+
+  /**
+   * Maps with same contents are equal
+   */
+  @Test
+  public void testEquals() {
+    ConcurrentIdentityHashMap map1 = map5();
+    ConcurrentIdentityHashMap map2 = map5();
+    assertEquals(map1, map2);
+    assertEquals(map2, map1);
+    map1.clear();
+    assertFalse(map1.equals(map2));
+    assertFalse(map2.equals(map1));
+  }
+
+  /**
+   * contains returns true for contained value
+   */
+  @Test
+  public void testContains() {
+    ConcurrentIdentityHashMap map = map5();
+    assertTrue(map.contains("A"));
+    assertFalse(map.contains("Z"));
+  }
+
+  /**
+   * containsKey returns true for contained key
+   */
+  @Test
+  public void testContainsKey() {
+    ConcurrentIdentityHashMap map = map5();
+    assertTrue(map.containsKey(ONE));
+    assertFalse(map.containsKey(ZERO));
+  }
+
+  /**
+   * containsValue returns true for held values
+   */
+  @Test
+  public void testContainsValue() {
+    ConcurrentIdentityHashMap map = map5();
+    assertTrue(map.contains("A"));
+    assertFalse(map.contains("Z"));
+  }
+
+  /**
+   * enumeration returns an enumeration containing the correct
+   * elements
+   */
+  @Test
+  public void testEnumeration() {
+    ConcurrentIdentityHashMap map = map5();
+    Enumeration e = map.elements();
+    int count = 0;
+    while (e.hasMoreElements()) {
+      count++;
+      e.nextElement();
+    }
+    assertEquals(5, count);
+  }
+
+  /**
+   * Clone creates an equal map
+   */
+  @Test
+  public void testClone() {
+    ConcurrentIdentityHashMap map = map5();
+    ConcurrentIdentityHashMap m2 = (ConcurrentIdentityHashMap) (map.clone());
+    assertEquals(map, m2);
+  }
+
+  /**
+   * get returns the correct element at the given key,
+   * or null if not present
+   */
+  @Test
+  public void testGet() {
+    ConcurrentIdentityHashMap map = map5();
+    assertEquals("A", (String) map.get(ONE));
+    ConcurrentIdentityHashMap empty = new ConcurrentIdentityHashMap();
+    assertNull(map.get("anything"));
+  }
+
+  /**
+   * isEmpty is true of empty map and false for non-empty
+   */
+  @Test
+  public void testIsEmpty() {
+    ConcurrentIdentityHashMap empty = new ConcurrentIdentityHashMap();
+    ConcurrentIdentityHashMap map = map5();
+    assertTrue(empty.isEmpty());
+    assertFalse(map.isEmpty());
+  }
+
+  /**
+   * keys returns an enumeration containing all the keys from the map
+   */
+  @Test
+  public void testKeys() {
+    ConcurrentIdentityHashMap map = map5();
+    Enumeration e = map.keys();
+    int count = 0;
+    while (e.hasMoreElements()) {
+      count++;
+      e.nextElement();
+    }
+    assertEquals(5, count);
+  }
+
+  /**
+   * keySet returns a Set containing all the keys
+   */
+  @Test
+  public void testKeySet() {
+    ConcurrentIdentityHashMap map = map5();
+    Set s = map.keySet();
+    assertEquals(5, s.size());
+    assertTrue(s.contains(ONE));
+    assertTrue(s.contains(TWO));
+    assertTrue(s.contains(THREE));
+    assertTrue(s.contains(FOUR));
+    assertTrue(s.contains(FIVE));
+  }
+
+  /**
+   * values collection contains all values
+   */
+  @Test
+  public void testValues() {
+    ConcurrentIdentityHashMap map = map5();
+    Collection s = map.values();
+    assertEquals(5, s.size());
+    assertTrue(s.contains("A"));
+    assertTrue(s.contains("B"));
+    assertTrue(s.contains("C"));
+    assertTrue(s.contains("D"));
+    assertTrue(s.contains("E"));
+  }
+
+  /**
+   * entrySet contains all pairs
+   */
+  @Test
+  public void testEntrySet() {
+    ConcurrentIdentityHashMap map = map5();
+    Set s = map.entrySet();
+    assertEquals(5, s.size());
+    Iterator it = s.iterator();
+    while (it.hasNext()) {
+      Map.Entry e = (Map.Entry) it.next();
+      assertTrue(
+          (e.getKey().equals(ONE) && "A".equals(e.getValue())) || (e.getKey().equals(TWO) && "B".equals(e.getValue())) || (e.getKey().equals(THREE)
+              && "C".equals(e.getValue())) || (e.getKey().equals(FOUR) && "D".equals(e.getValue())) || (e.getKey().equals(FIVE) && "E".equals(
+              e.getValue())));
+    }
+  }
+
+  /**
+   * putAll  adds all key-value pairs from the given map
+   */
+  @Test
+  public void testPutAll() {
+    ConcurrentIdentityHashMap empty = new ConcurrentIdentityHashMap();
+    ConcurrentIdentityHashMap map = map5();
+    empty.putAll(map);
+    assertEquals(5, empty.size());
+    assertTrue(empty.containsKey(ONE));
+    assertTrue(empty.containsKey(TWO));
+    assertTrue(empty.containsKey(THREE));
+    assertTrue(empty.containsKey(FOUR));
+    assertTrue(empty.containsKey(FIVE));
+  }
+
+  /**
+   * putIfAbsent works when the given key is not present
+   */
+  @Test
+  public void testPutIfAbsent() {
+    ConcurrentIdentityHashMap map = map5();
+    map.putIfAbsent(SIX, "Z");
+    assertTrue(map.containsKey(SIX));
+  }
+
+  /**
+   * putIfAbsent does not add the pair if the key is already present
+   */
+  @Test
+  public void testPutIfAbsent2() {
+    ConcurrentIdentityHashMap map = map5();
+    assertEquals("A", map.putIfAbsent(ONE, "Z"));
+  }
+
+  /**
+   * replace fails when the given key is not present
+   */
+  @Test
+  public void testReplace() {
+    ConcurrentIdentityHashMap map = map5();
+    assertNull(map.replace(SIX, "Z"));
+    assertFalse(map.containsKey(SIX));
+  }
+
+  /**
+   * replace succeeds if the key is already present
+   */
+  @Test
+  public void testReplace2() {
+    ConcurrentIdentityHashMap map = map5();
+    assertNotNull(map.replace(ONE, "Z"));
+    assertEquals("Z", map.get(ONE));
+  }
+
+  /**
+   * replace value fails when the given key not mapped to expected value
+   */
+  @Test
+  public void testReplaceValue() {
+    ConcurrentIdentityHashMap map = map5();
+    assertEquals("A", map.get(ONE));
+    assertFalse(map.replace(ONE, "Z", "Z"));
+    assertEquals("A", map.get(ONE));
+  }
+
+  /**
+   * replace value succeeds when the given key mapped to expected value
+   */
+  @Test
+  public void testReplaceValue2() {
+    ConcurrentIdentityHashMap map = map5();
+    assertEquals("A", map.get(ONE));
+    assertTrue(map.replace(ONE, "A", "Z"));
+    assertEquals("Z", map.get(ONE));
+  }
+
+  /**
+   * remove removes the correct key-value pair from the map
+   */
+  @Test
+  public void testRemove() {
+    ConcurrentIdentityHashMap map = map5();
+    map.remove(FIVE);
+    assertEquals(4, map.size());
+    assertFalse(map.containsKey(FIVE));
+  }
+
+  /**
+   * remove(key,value) removes only if pair present
+   */
+  @Test
+  public void testRemove2() {
+    ConcurrentIdentityHashMap map = map5();
+    map.remove(FIVE, "E");
+    assertEquals(4, map.size());
+    assertFalse(map.containsKey(FIVE));
+    map.remove(FOUR, "A");
+    assertEquals(4, map.size());
+    assertTrue(map.containsKey(FOUR));
+  }
+
+  /**
+   * size returns the correct values
+   */
+  @Test
+  public void testSize() {
+    ConcurrentIdentityHashMap map = map5();
+    ConcurrentIdentityHashMap empty = new ConcurrentIdentityHashMap();
+    assertEquals(0, empty.size());
+    assertEquals(5, map.size());
+  }
+
+  /**
+   * toString contains toString of elements
+   */
+  @Test
+  public void testToString() {
+    ConcurrentIdentityHashMap map = map5();
+    String s = map.toString();
+    for (int i = 1; i <= 5; ++i) {
+      assertTrue(s.indexOf(String.valueOf(i)) >= 0);
+    }
+  }
+
+  // Exception tests
+
+  /**
+   * Cannot create with negative capacity
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructor1() {
+    new ConcurrentIdentityHashMap(-1, 0, 1);
+    fail("Should throw exception");
+  }
+
+  /**
+   * Cannot create with negative concurrency level
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructor2() {
+    new ConcurrentIdentityHashMap(1, 0, -1);
+    fail("Should throw exception");
+  }
+
+  /**
+   * Cannot create with only negative capacity
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructor3() {
+    new ConcurrentIdentityHashMap(-1);
+    fail("Should throw exception");
+  }
+
+  /**
+   * get(null) returns value
+   */
+  @Test
+  public void testGet_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    assertEquals(c.get(null), null);
+  }
+
+  /**
+   * containsKey(null) returns false
+   */
+  @Test
+  public void testContainsKey_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    assertFalse(c.containsKey(null));
+  }
+
+  /**
+   * containsValue(null) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testContainsValue_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.containsValue(null);
+    fail("Should throw exception");
+  }
+
+  /**
+   * contains(null) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testContains_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.contains(null);
+    fail("Should throw exception");
+  }
+
+  /**
+   * put(null,x) throws NPE
+   */
+  @Test
+  public void testPut1_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    assertEquals(null, c.put(null, "whatever"));
+  }
+
+  /**
+   * put(x, null) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testPut2_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.put("whatever", null);
+    fail("Should throw exception");
+  }
+
+  /**
+   * putIfAbsent(null, x) returns previous value
+   */
+  @Test
+  public void testPutIfAbsent1_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    assertEquals(c.putIfAbsent(null, "whatever"), null);
+  }
+
+  /**
+   * replace(null, x) replaces previous value
+   */
+  @Test
+  public void testReplace_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.replace(null, "whatever");
+  }
+
+  /**
+   * replace(null, x, y) previous value
+   */
+  @Test
+  public void testReplaceValue_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.replace(null, ONE, "whatever");
+  }
+
+  /**
+   * putIfAbsent(x, null) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testPutIfAbsent2_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.putIfAbsent("whatever", null);
+    fail("Should throw exception");
+  }
+
+  /**
+   * replace(x, null) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testReplace2_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.replace("whatever", null);
+    fail("Should throw exception");
+  }
+
+  /**
+   * replace(x, null, y) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testReplaceValue2_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.replace("whatever", null, "A");
+    fail("Should throw exception");
+  }
+
+  /**
+   * replace(x, y, null) throws NPE
+   */
+  @Test(expected = NullPointerException.class)
+  public void testReplaceValue3_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.replace("whatever", ONE, null);
+    fail("Should throw exception");
+  }
+
+  /**
+   * remove(null) returns previous value
+   */
+  @Test
+  public void testRemove1_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.put("sadsdf", "asdads");
+    assertEquals(c.remove(null), null);
+  }
+
+  /**
+   * remove(null, x) returns previous value
+   */
+  @Test
+  public void testRemove2_NullPointerException() {
+    ConcurrentIdentityHashMap c = new ConcurrentIdentityHashMap(5);
+    c.put("sadsdf", "asdads");
+    assertFalse(c.remove(null, "whatever"));
+  }
+
+  /**
+   * SetValue of an EntrySet entry sets value in the map.
+   */
+  @Test
+  public void testSetValueWriteThrough() {
+    // Adapted from a bug report by Eric Zoerner
+    ConcurrentIdentityHashMap map = new ConcurrentIdentityHashMap(2, 5.0f, 1);
+    assertTrue(map.isEmpty());
+    for (int i = 0; i < 20; i++) {
+      map.put(new Integer(i), new Integer(i));
+    }
+    assertFalse(map.isEmpty());
+    Map.Entry entry1 = (Map.Entry) map.entrySet().iterator().next();
+
+    // assert that entry1 is not 16
+    assertTrue("entry is 16, test not valid", !entry1.getKey().equals(new Integer(16)));
+
+    // remove 16 (a different key) from map
+    // which just happens to cause entry1 to be cloned in map
+    map.remove(new Integer(16));
+    entry1.setValue("XYZ");
+    assertTrue(map.containsValue("XYZ")); // fails
+  }
+
+  /**
+   * Return the shortest timed delay. This could
+   * be reimplemented to use for example a Property.
+   */
+  protected long getShortDelay() {
+    return 50;
+  }
+
+  /**
+   * Set delays as multiples of SHORT_DELAY.
+   */
+  protected void setDelays() {
+    shortDelayMs = getShortDelay();
+    smallDelayMs = shortDelayMs * 5;
+    mediumDelayMs = shortDelayMs * 10;
+    longDelayMs = shortDelayMs * 50;
+  }
+
+  /**
+   * Initialize test to indicate that no thread assertions have failed
+   */
+  public void setUp() {
+    setDelays();
+    threadFailed = false;
+  }
+
+  /**
+   * Trigger test case failure if any thread assertions have failed
+   */
+  public void tearDown() {
+    assertFalse(threadFailed);
+  }
+}

--- a/toothpick/src/main/java/toothpick/MemberInjector.java
+++ b/toothpick/src/main/java/toothpick/MemberInjector.java
@@ -3,7 +3,7 @@ package toothpick;
 /**
  * Inject member of an instance of a class.
  * All injected members are gonna be obtained in the scope of the current scope.
- * MemberInjector are discovered via a {@link AbstractMemberInjectorRegistry}.
+ * MemberInjector are discovered via a {@code AbstractMemberInjectorRegistry}.
  * Implementations are generated during annotation processing.
  * As soon as a class as an {@link javax.inject.Inject} annotated field or method,
  * a member scope is created. All classes that need to be injected via toothpick


### PR DESCRIPTION
DO NOT MERGE

Besides Daniel, I would love Michael & Henri to review this.
The goal of this PR is to 
* make TP crash free in a multi threading context. It appears that we have been making a few mistakes on this since the beginning. 
* pass tests that heavily use the data structure (scope tree) concurrently
* make TP lock free. Each injection will see a snapshot of TP scope tree, before or after any modification but not in between. This makes the most normal usages of TP much faster.

This version provides an improvement for massive DI  : 

![image](https://cloud.githubusercontent.com/assets/1832925/14947077/eb7fad90-0fe1-11e6-8aa6-acd71da5f9da.png)

For 55 K injections. 