### PR TITLE
Sni/cycle check multi thread

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/Configuration.java
+++ b/toothpick-runtime/src/main/java/toothpick/Configuration.java
@@ -1,6 +1,7 @@
 package toothpick;
 
 import java.util.Stack;
+import java.util.concurrent.locks.ReentrantLock;
 import toothpick.config.Binding;
 
 import static java.lang.String.format;
@@ -23,6 +24,8 @@ public abstract class Configuration {
   public static void development() {
     instance = new Configuration() {
       private Stack<Class> cycleDetectionStack = new Stack<>();
+      //used to make the cycle check atomic. 
+      private ReentrantLock reentrantLock = new ReentrantLock();
 
       @Override
       void checkIllegalBinding(Binding binding) {
@@ -37,11 +40,13 @@ public abstract class Configuration {
         }
 
         cycleDetectionStack.push(clazz);
+        reentrantLock.lock();
       }
 
       @Override
       void checkCyclesEnd() {
         cycleDetectionStack.pop();
+        reentrantLock.unlock();
       }
     };
   }

--- a/toothpick-runtime/src/main/java/toothpick/Configuration.java
+++ b/toothpick-runtime/src/main/java/toothpick/Configuration.java
@@ -8,7 +8,7 @@ import static java.lang.String.format;
 
 public abstract class Configuration {
 
-  public static volatile Configuration instance;
+  /*package-private.*/ static Configuration instance;
 
   abstract void checkIllegalBinding(Binding binding);
 
@@ -18,13 +18,13 @@ public abstract class Configuration {
 
   static {
     //default mode is production
-    production();
+    instance = production();
   }
 
-  public static void development() {
-    instance = new Configuration() {
+  public static Configuration development() {
+    return new Configuration() {
       private Stack<Class> cycleDetectionStack = new Stack<>();
-      //used to make the cycle check atomic. 
+      //used to make the cycle check atomic.
       private ReentrantLock reentrantLock = new ReentrantLock();
 
       @Override
@@ -51,8 +51,8 @@ public abstract class Configuration {
     };
   }
 
-  public static void production() {
-    instance = new Configuration() {
+  public static Configuration production() {
+    return new Configuration() {
       @Override
       void checkIllegalBinding(Binding binding) {
         //do nothing

--- a/toothpick-runtime/src/main/java/toothpick/ToothPick.java
+++ b/toothpick-runtime/src/main/java/toothpick/ToothPick.java
@@ -108,4 +108,8 @@ public final class ToothPick {
       removeScopeAndChildrenFromMap(childScope);
     }
   }
+
+  public static void setConfiguration(Configuration configuration) {
+    Configuration.setConfiguration(configuration);
+  }
 }

--- a/toothpick-runtime/src/test/java/toothpick/getInstance/CycleCheckTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/getInstance/CycleCheckTest.java
@@ -3,14 +3,16 @@ package toothpick.getInstance;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import toothpick.Configuration;
 import toothpick.CyclicDependencyException;
 import toothpick.Scope;
 import toothpick.ScopeImpl;
+import toothpick.ToothPick;
 import toothpick.ToothPickBaseTest;
 import toothpick.data.CyclicFoo;
 
 import static org.junit.Assert.fail;
+import static toothpick.Configuration.development;
+import static toothpick.Configuration.production;
 
 /*
  * Creates a instance in the simplest possible way
@@ -20,12 +22,12 @@ public class CycleCheckTest extends ToothPickBaseTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Configuration.development();
+    ToothPick.setConfiguration(development());
   }
 
   @AfterClass
   public static void staticTearDown() throws Exception {
-    Configuration.production();
+    ToothPick.setConfiguration(production());
   }
 
   @Test(expected = CyclicDependencyException.class)


### PR DESCRIPTION
Protect cycle detection in multi-thread. This implies a slow down in TP in debug configuration.
Make the API more dev friendly to change configuration.