### PR TITLE
spliting registry getter method length to avoid warning

### DIFF
--- a/toothpick-compiler/src/main/java/toothpick/compiler/factory/FactoryProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/factory/FactoryProcessor.java
@@ -327,4 +327,9 @@ public class FactoryProcessor extends ToothpickProcessor {
   void setToothpickRegistryChildrenPackageNameList(List<String> toothpickRegistryChildrenPackageNameList) {
     this.toothpickRegistryChildrenPackageNameList = toothpickRegistryChildrenPackageNameList;
   }
+
+  //used for testing only
+  void setToothpickExcludeFilters(String toothpickExcludeFilters) {
+    this.toothpickExcludeFilters = toothpickExcludeFilters;
+  }
 }

--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
@@ -176,4 +176,9 @@ public class MemberInjectorProcessor extends ToothpickProcessor {
   void setToothpickRegistryChildrenPackageNameList(List<String> toothpickRegistryChildrenPackageNameList) {
     this.toothpickRegistryChildrenPackageNameList = toothpickRegistryChildrenPackageNameList;
   }
+
+  //used for testing only
+  void setToothpickExcludeFilters(String toothpickExcludeFilters) {
+    this.toothpickExcludeFilters = toothpickExcludeFilters;
+  }
 }

--- a/toothpick-compiler/src/main/java/toothpick/compiler/registry/generators/RegistryGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/registry/generators/RegistryGenerator.java
@@ -7,6 +7,11 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import toothpick.compiler.common.generators.CodeGenerator;
@@ -21,6 +26,8 @@ import toothpick.registries.MemberInjectorRegistry;
  */
 public class RegistryGenerator extends CodeGenerator {
 
+  /* @VisibleForTesting */ static int INJECTION_TARGETS_PER_GETTER_METHOD = 200;
+
   private RegistryInjectionTarget registryInjectionTarget;
 
   public RegistryGenerator(RegistryInjectionTarget registryInjectionTarget) {
@@ -34,7 +41,7 @@ public class RegistryGenerator extends CodeGenerator {
         .superclass(ClassName.get(registryInjectionTarget.superClass));
 
     emitConstructor(registryTypeSpec);
-    emitGetFactoryMethod(registryTypeSpec);
+    emitGetterMethods(registryTypeSpec);
 
     JavaFile javaFile = JavaFile.builder(registryInjectionTarget.packageName, registryTypeSpec.build())
         .addFileComment("Generated code from Toothpick. Do not modify!")
@@ -56,7 +63,7 @@ public class RegistryGenerator extends CodeGenerator {
     registryTypeSpec.addMethod(constructor.build());
   }
 
-  private void emitGetFactoryMethod(TypeSpec.Builder registryTypeSpec) {
+  private void emitGetterMethods(TypeSpec.Builder registryTypeSpec) {
     TypeVariableName t = TypeVariableName.get("T");
     MethodSpec.Builder getMethod = MethodSpec.methodBuilder(registryInjectionTarget.getterName)
         .addTypeVariable(t)
@@ -66,12 +73,22 @@ public class RegistryGenerator extends CodeGenerator {
 
     //the ultimate part of the switch is about converting $ to .
     //this is a bad hack, but the easiest workaroung to injectionTarget.getQualifiedName() using only . and not $ for FQN...
-    CodeBlock.Builder switchBlockBuilder = CodeBlock.builder().beginControlFlow("switch($L)", "clazz.getName().replace('$','.')");
+    getMethod.addStatement("String className = clazz.getName().replace('$$','.')");
+    int numOfBuckets = getNumberOfBuckets(registryInjectionTarget.injectionTargetList);
+    getMethod.addStatement("int bucket = (className.hashCode() & $L)", numOfBuckets - 1);
+    CodeBlock.Builder switchBlockBuilder = CodeBlock.builder().beginControlFlow("switch(bucket)");
 
-    for (TypeElement injectionTarget : registryInjectionTarget.injectionTargetList) {
-      switchBlockBuilder.add("case ($S):" + LINE_SEPARATOR, injectionTarget.getQualifiedName().toString());
-      String typeSimpleName = registryInjectionTarget.type.getSimpleName();
-      switchBlockBuilder.addStatement("return ($L<T>) new $L$$$$$L()", typeSimpleName, getGeneratedFQNClassName(injectionTarget), typeSimpleName);
+    List<MethodSpec> getterMethodForBucketList = new ArrayList<>(numOfBuckets);
+    Map<Integer, List<TypeElement>> getterMethodBuckets = getGetterMethodBuckets(registryInjectionTarget.injectionTargetList);
+    for (int i = 0; i < numOfBuckets; i++) {
+      List<TypeElement> methodBucket = getterMethodBuckets.get(i);
+      if (methodBucket == null) {
+        methodBucket = Collections.emptyList();
+      }
+      MethodSpec getterMethodForBucket = generateGetterMethod(methodBucket, i);
+      getterMethodForBucketList.add(getterMethodForBucket);
+      switchBlockBuilder.add("case ($L):" + LINE_SEPARATOR, i);
+      switchBlockBuilder.addStatement("return $L(clazz, className)", getterMethodForBucket.name);
     }
 
     switchBlockBuilder.add("default:" + LINE_SEPARATOR);
@@ -79,6 +96,63 @@ public class RegistryGenerator extends CodeGenerator {
     switchBlockBuilder.endControlFlow();
     getMethod.addCode(switchBlockBuilder.build());
     registryTypeSpec.addMethod(getMethod.build());
+    registryTypeSpec.addMethods(getterMethodForBucketList);
+  }
+
+  private MethodSpec generateGetterMethod(List<TypeElement> getterMethodBucket, int index) {
+    TypeVariableName t = TypeVariableName.get("T");
+    MethodSpec.Builder getMethod = MethodSpec.methodBuilder(registryInjectionTarget.getterName + "Bucket" + index)
+        .addTypeVariable(t)
+        .addModifiers(Modifier.PRIVATE)
+        .addParameter(ParameterizedTypeName.get(ClassName.get(Class.class), t), "clazz")
+        .addParameter(String.class, "className")
+        .returns(ParameterizedTypeName.get(ClassName.get(registryInjectionTarget.type), t));
+
+    CodeBlock.Builder switchBlockBuilder = CodeBlock.builder().beginControlFlow("switch(className)");
+    String typeSimpleName = registryInjectionTarget.type.getSimpleName();
+
+    for (TypeElement injectionTarget : getterMethodBucket) {
+      switchBlockBuilder.add("case ($S):" + LINE_SEPARATOR, injectionTarget.getQualifiedName().toString());
+      switchBlockBuilder.addStatement("return ($L<T>) new $L$$$$$L()", typeSimpleName, getGeneratedFQNClassName(injectionTarget), typeSimpleName);
+    }
+
+    switchBlockBuilder.add("default:" + LINE_SEPARATOR);
+    switchBlockBuilder.addStatement("return $L(clazz)", registryInjectionTarget.childrenGetterName);
+    switchBlockBuilder.endControlFlow();
+    getMethod.addCode(switchBlockBuilder.build());
+    return getMethod.build();
+  }
+
+  private Map<Integer, List<TypeElement>> getGetterMethodBuckets(List<TypeElement> injectionTargetList) {
+    int numOfBuckets = getNumberOfBuckets(injectionTargetList);
+    Map<Integer, List<TypeElement>> getterMethodBuckets = new HashMap<>();
+
+    for (TypeElement injectionTarget : injectionTargetList) {
+      int index = injectionTarget.getQualifiedName().toString().hashCode() & (numOfBuckets - 1);
+      List<TypeElement> methodBucket = getterMethodBuckets.get(index);
+      if (methodBucket == null) {
+        methodBucket = new ArrayList<>();
+        getterMethodBuckets.put(index, methodBucket);
+      }
+      methodBucket.add(injectionTarget);
+    }
+
+    return getterMethodBuckets;
+  }
+
+  private int getNumberOfBuckets(List<TypeElement> injectionTargetList) {
+    int minNumOfBuckets = (injectionTargetList.size() + INJECTION_TARGETS_PER_GETTER_METHOD - 1) / INJECTION_TARGETS_PER_GETTER_METHOD;
+    return roundUpToPowerOfTwo(minNumOfBuckets);
+  }
+
+  private int roundUpToPowerOfTwo(int i) {
+    i--;
+    i |= i >>>  1;
+    i |= i >>>  2;
+    i |= i >>>  4;
+    i |= i >>>  8;
+    i |= i >>> 16;
+    return i + 1;
   }
 
   @Override

--- a/toothpick-compiler/src/test/java/toothpick/compiler/factory/ProcessorTestUtilities.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/factory/ProcessorTestUtilities.java
@@ -18,9 +18,14 @@ final class ProcessorTestUtilities {
   }
 
   static Iterable<? extends Processor> factoryProcessors(String toothpickRegistryPackageName, List<String> toothpickRegistryChildrenPackageNameList) {
+    return factoryProcessors(toothpickRegistryPackageName, toothpickRegistryChildrenPackageNameList, "java.*,android.*");
+  }
+
+  static Iterable<? extends Processor> factoryProcessors(String toothpickRegistryPackageName, List<String> toothpickRegistryChildrenPackageNameList, String toothpickExcludeFilters) {
     FactoryProcessor factoryProcessor = new FactoryProcessor();
     factoryProcessor.setToothpickRegistryPackageName(toothpickRegistryPackageName);
     factoryProcessor.setToothpickRegistryChildrenPackageNameList(toothpickRegistryChildrenPackageNameList);
+    factoryProcessor.setToothpickExcludeFilters(toothpickExcludeFilters);
     return Arrays.asList(factoryProcessor);
   }
 }

--- a/toothpick-compiler/src/test/java/toothpick/compiler/memberinjector/MemberInjectorRegistryTest.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/memberinjector/MemberInjectorRegistryTest.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
+import toothpick.compiler.registry.generators.RegistryGeneratorTestUtilities;
 
 import static com.google.common.truth.Truth.assert_;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
@@ -25,6 +26,7 @@ public class MemberInjectorRegistryTest {
         "package toothpick;", //
         "", //
         "import java.lang.Class;", //
+        "import java.lang.String;", //
         "import toothpick.registries.memberinjector.AbstractMemberInjectorRegistry;", //
         "", //
         "public final class MemberInjectorRegistry extends AbstractMemberInjectorRegistry {", //
@@ -32,7 +34,18 @@ public class MemberInjectorRegistryTest {
         "  }", //
         "", //
         "  public <T> MemberInjector<T> getMemberInjector(Class<T> clazz) {", //
-        "    switch(clazz.getName().replace('$','.')) {", //
+        "    String className = clazz.getName().replace('$','.');", //
+        "    int bucket = (className.hashCode() & 0);", //
+        "    switch(bucket) {", //
+        "      case (0):", //
+        "      return getMemberInjectorBucket0(clazz, className);", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "", //
+        "  private <T> MemberInjector<T> getMemberInjectorBucket0(Class<T> clazz, String className) {", //
+        "    switch(className) {", //
         "      case (\"test.TestASimpleRegistry\"):", //
         "      return (MemberInjector<T>) new test.TestASimpleRegistry$$MemberInjector();", //
         "      default:", //
@@ -44,7 +57,7 @@ public class MemberInjectorRegistryTest {
 
     assert_().about(javaSource())
         .that(source)
-        .processedWith(toothpick.compiler.memberinjector.ProcessorTestUtilities.memberInjectorProcessors("toothpick", Collections.EMPTY_LIST))
+        .processedWith(ProcessorTestUtilities.memberInjectorProcessors("toothpick", Collections.EMPTY_LIST))
         .compilesWithoutError()
         .and()
         .generatesSources(expectedSource);
@@ -64,6 +77,7 @@ public class MemberInjectorRegistryTest {
         "package toothpick;", //
         "", //
         "import java.lang.Class;", //
+        "import java.lang.String;", //
         "import toothpick.registries.memberinjector.AbstractMemberInjectorRegistry;", //
         "", //
         "public final class MemberInjectorRegistry extends AbstractMemberInjectorRegistry {", //
@@ -73,7 +87,18 @@ public class MemberInjectorRegistryTest {
         "  }", //
         "", //
         "  public <T> MemberInjector<T> getMemberInjector(Class<T> clazz) {", //
-        "    switch(clazz.getName().replace('$','.')) {", //
+        "    String className = clazz.getName().replace('$','.');", //
+        "    int bucket = (className.hashCode() & 0);", //
+        "    switch(bucket) {", //
+        "      case (0):", //
+        "      return getMemberInjectorBucket0(clazz, className);", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "", //
+        "  private <T> MemberInjector<T> getMemberInjectorBucket0(Class<T> clazz, String className) {", //
+        "    switch(className) {", //
         "      case (\"test.TestARegistry\"):", //
         "      return (MemberInjector<T>) new test.TestARegistry$$MemberInjector();", //
         "      default:", //
@@ -85,8 +110,139 @@ public class MemberInjectorRegistryTest {
 
     assert_().about(javaSource())
         .that(source)
-        .processedWith(
-            toothpick.compiler.memberinjector.ProcessorTestUtilities.memberInjectorProcessors("toothpick", Arrays.asList("toothpick", "toothpick")))
+        .processedWith(ProcessorTestUtilities.memberInjectorProcessors("toothpick", Arrays.asList("toothpick", "toothpick")))
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void testARegistry_withNoFactories() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.TestARegistryWithNoFactories", Joiner.on('\n').join(//
+        "package test;", //
+        "import javax.inject.Inject;", //
+        "public class TestARegistryWithNoFactories {", //
+        "  @Inject String s; ", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("toothpick/MemberInjectorRegistry", Joiner.on('\n').join(//
+        "package toothpick;", //
+        "", //
+        "import java.lang.Class;", //
+        "import toothpick.registries.memberinjector.AbstractMemberInjectorRegistry;", //
+        "", //
+        "public final class MemberInjectorRegistry extends AbstractMemberInjectorRegistry {", //
+        "  public MemberInjectorRegistry() {", //
+        "  }", //
+        "", //
+        "  public <T> MemberInjector<T> getMemberInjector(Class<T> clazz) {", //
+        "    String className = clazz.getName().replace('$','.');", //
+        "    int bucket = (className.hashCode() & -1);", //
+        "    switch(bucket) {", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "}" //
+    ));
+
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(ProcessorTestUtilities.memberInjectorProcessors("toothpick", Collections.EMPTY_LIST, "java.*,android.*,test.*"))
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test public void testARegistry_withMoreThanOneBucket() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.TestARegistryWithMoreThanOneBucket", Joiner.on('\n').join(//
+        "package test;", //
+        "import javax.inject.Inject;", //
+        "public class TestARegistryWithMoreThanOneBucket {", //
+        "  @Inject String s;", //
+        "  public static class InnerClass1 {", //
+        "    @Inject String s;", //
+        "  }", //
+        "  public static class InnerClass2 {", //
+        "    @Inject String s;", //
+        "  }", //
+        "  public static class InnerClass3 {", //
+        "    @Inject String s;", //
+        "  }", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("toothpick/MemberInjectorRegistry", Joiner.on('\n').join(//
+        "package toothpick;", //
+        "", //
+        "import java.lang.Class;", //
+        "import java.lang.String;", //
+        "import toothpick.registries.memberinjector.AbstractMemberInjectorRegistry;", //
+        "", //
+        "public final class MemberInjectorRegistry extends AbstractMemberInjectorRegistry {", //
+        "  public MemberInjectorRegistry() {", //
+        "  }", //
+        "", //
+        "  public <T> MemberInjector<T> getMemberInjector(Class<T> clazz) {", //
+        "    String className = clazz.getName().replace('$','.');", //
+        "    int bucket = (className.hashCode() & 3);", //
+        "    switch(bucket) {", //
+        "      case (0):", //
+        "      return getMemberInjectorBucket0(clazz, className);", //
+        "      case (1):", //
+        "      return getMemberInjectorBucket1(clazz, className);", //
+        "      case (2):", //
+        "      return getMemberInjectorBucket2(clazz, className);", //
+        "      case (3):", //
+        "      return getMemberInjectorBucket3(clazz, className);", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "", //
+        "  private <T> MemberInjector<T> getMemberInjectorBucket0(Class<T> clazz, String className) {", //
+        "    switch(className) {", //
+        "      case (\"test.TestARegistryWithMoreThanOneBucket\"):", //
+        "      return (MemberInjector<T>) new test.TestARegistryWithMoreThanOneBucket$$MemberInjector();", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "", //
+        "  private <T> MemberInjector<T> getMemberInjectorBucket1(Class<T> clazz, String className) {", //
+        "    switch(className) {", //
+        "      case (\"test.TestARegistryWithMoreThanOneBucket.InnerClass1\"):", //
+        "      return (MemberInjector<T>) new test.TestARegistryWithMoreThanOneBucket$InnerClass1$$MemberInjector();", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "", //
+        "  private <T> MemberInjector<T> getMemberInjectorBucket2(Class<T> clazz, String className) {", //
+        "    switch(className) {", //
+        "      case (\"test.TestARegistryWithMoreThanOneBucket.InnerClass2\"):", //
+        "      return (MemberInjector<T>) new test.TestARegistryWithMoreThanOneBucket$InnerClass2$$MemberInjector();", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "", //
+        "  private <T> MemberInjector<T> getMemberInjectorBucket3(Class<T> clazz, String className) {", //
+        "    switch(className) {", //
+        "      case (\"test.TestARegistryWithMoreThanOneBucket.InnerClass3\"):", //
+        "      return (MemberInjector<T>) new test.TestARegistryWithMoreThanOneBucket$InnerClass3$$MemberInjector();", //
+        "      default:", //
+        "      return getMemberInjectorInChildrenRegistries(clazz);", //
+        "    }", //
+        "  }", //
+        "}" //
+    ));
+
+    RegistryGeneratorTestUtilities.setInjectionTarjetsPerGetterMethod(1);
+
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(ProcessorTestUtilities.memberInjectorProcessors("toothpick", Collections.EMPTY_LIST))
         .compilesWithoutError()
         .and()
         .generatesSources(expectedSource);

--- a/toothpick-compiler/src/test/java/toothpick/compiler/memberinjector/ProcessorTestUtilities.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/memberinjector/ProcessorTestUtilities.java
@@ -14,9 +14,15 @@ final class ProcessorTestUtilities {
 
   static Iterable<? extends Processor> memberInjectorProcessors(String toothpickRegistryPackageName,
       List<String> toothpickRegistryChildrenPackageNameList) {
-    MemberInjectorProcessor factoryProcessor = new MemberInjectorProcessor();
-    factoryProcessor.setToothpickRegistryPackageName(toothpickRegistryPackageName);
-    factoryProcessor.setToothpickRegistryChildrenPackageNameList(toothpickRegistryChildrenPackageNameList);
-    return Arrays.asList(factoryProcessor);
+    return memberInjectorProcessors(toothpickRegistryPackageName, toothpickRegistryChildrenPackageNameList, "java.*,android.*");
+  }
+
+  static Iterable<? extends Processor> memberInjectorProcessors(String toothpickRegistryPackageName,
+      List<String> toothpickRegistryChildrenPackageNameList, String toothpickExcludeFilters) {
+    MemberInjectorProcessor memberInjectorProcessor = new MemberInjectorProcessor();
+    memberInjectorProcessor.setToothpickRegistryPackageName(toothpickRegistryPackageName);
+    memberInjectorProcessor.setToothpickRegistryChildrenPackageNameList(toothpickRegistryChildrenPackageNameList);
+    memberInjectorProcessor.setToothpickExcludeFilters(toothpickExcludeFilters);
+    return Arrays.asList(memberInjectorProcessor);
   }
 }

--- a/toothpick-compiler/src/test/java/toothpick/compiler/registry/generators/RegistryGeneratorTestUtilities.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/registry/generators/RegistryGeneratorTestUtilities.java
@@ -1,0 +1,10 @@
+package toothpick.compiler.registry.generators;
+
+public final class RegistryGeneratorTestUtilities {
+  private RegistryGeneratorTestUtilities() {
+  }
+
+  public static void setInjectionTarjetsPerGetterMethod(int injectionTarjetsPerMethod) {
+    RegistryGenerator.INJECTION_TARGETS_PER_GETTER_METHOD = injectionTarjetsPerMethod;
+  }
+}


### PR DESCRIPTION
For big project, with a lot of factories and member injectors, we generate huge factories. That makes ART complain about the `getFactory`, `getMemberInjection` length and they don't get compiled:

```java
Method exceeds compiler instruction limit: 19072 in toothpick.Factory com.groupon.FactoryRegistry.getFactory(java.lang.Class)
Method exceeds compiler instruction limit: 19408 in toothpick.MemberInjector com.groupon.MemberInjectorRegistry.getMemberInjector(java.lang.Class)
```

Splitting the getter methods into buckets using the same approach as a HashMap:

* Use HashCode
* Create power-of-two buckets and use the last bits of the hash code to classify the factories/member injectors.