### PR TITLE
Smooth Sample Presenter crash fixed and relocated logic for leaving p…

### DIFF
--- a/smoothie-sample/src/main/java/com/example/smoothie/RxMVPActivity.java
+++ b/smoothie-sample/src/main/java/com/example/smoothie/RxMVPActivity.java
@@ -47,16 +47,13 @@ public class RxMVPActivity extends Activity {
   protected void onDestroy() {
     Toothpick.closeScope(this);
     subscription.unsubscribe();
+    if (isFinishing()) {
+      //when we leave the presenter flow,
+      //we close its scope
+      rxPresenter.stop();
+      Toothpick.closeScope(PRESENTER_SCOPE);
+    }
     super.onDestroy();
-  }
-
-  @Override
-  public void onBackPressed() {
-    //when we leave the presenter flow,
-    //we close its scope
-    rxPresenter.stop();
-    Toothpick.closeScope(PRESENTER_SCOPE);
-    super.onBackPressed();
   }
 
   @javax.inject.Scope

--- a/smoothie-sample/src/main/java/com/example/smoothie/deps/RxPresenter.java
+++ b/smoothie-sample/src/main/java/com/example/smoothie/deps/RxPresenter.java
@@ -2,6 +2,7 @@ package com.example.smoothie.deps;
 
 import com.example.smoothie.RxMVPActivity;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
 import rx.Observable;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
@@ -15,6 +16,7 @@ public class RxPresenter {
   private final ConnectableObservable<Long> timeObservable;
   private final Subscription connect;
 
+  @Inject
   public RxPresenter() {
     timeObservable = Observable.interval(1, TimeUnit.SECONDS) //
         .subscribeOn(Schedulers.newThread()) //


### PR DESCRIPTION
…resenter flow

Moved the logic to close the flow of `RxMVPActivity` to `onDestroy` when `isFinishing` is `true` to catch any potential place where an Activity is finishing (This will scale better and make a better example IMHO)

Also noticed a crash in presenter flow, stack trace below:
```
FATAL EXCEPTION: main
        Process: com.example.smoothie, PID: 2758
        java.lang.RuntimeException: Unable to start activity ComponentInfo{com.example.smoothie/com.example.smoothie.RxMVPActivity}: toothpick.registries.NoFactoryFoundException: No factory could be found for class com.example.smoothie.deps.RxPresenter. Check that the class has either a @Inject annotated constructor or contains @Inject annotated members. If using Registries, check that they are properly setup with annotation processor arguments.
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
            at android.app.ActivityThread.-wrap11(ActivityThread.java)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:148)
            at android.app.ActivityThread.main(ActivityThread.java:5417)
            at java.lang.reflect.Method.invoke(Native Method)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
         Caused by: toothpick.registries.NoFactoryFoundException: No factory could be found for class com.example.smoothie.deps.RxPresenter. Check that the class has either a @Inject annotated constructor or contains @Inject annotated members. If using Registries, check that they are properly setup with annotation processor arguments.
            at toothpick.registries.FactoryRegistryLocator.getFactoryUsingRegistries(FactoryRegistryLocator.java:49)
            at toothpick.Configuration$ReflectionFreeConfiguration.getFactory(Configuration.java:163)
            at toothpick.registries.FactoryRegistryLocator.getFactory(FactoryRegistryLocator.java:38)
            at toothpick.ScopeImpl.lookupProvider(ScopeImpl.java:290)
            at toothpick.ScopeImpl.getInstance(ScopeImpl.java:48)
            at com.example.smoothie.RxMVPActivity$$MemberInjector.inject(RxMVPActivity$$MemberInjector.java:11)
            at com.example.smoothie.RxMVPActivity$$MemberInjector.inject(RxMVPActivity$$MemberInjector.java:8)
            at toothpick.InjectorImpl.inject(InjectorImpl.java:25)
            at toothpick.Toothpick.inject(Toothpick.java:108)
            at com.example.smoothie.RxMVPActivity.onCreate(RxMVPActivity.java:37)
            at android.app.Activity.performCreate(Activity.java:6237)
            at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1107)
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2369)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476) 
            at android.app.ActivityThread.-wrap11(ActivityThread.java) 
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344) 
            at android.os.Handler.dispatchMessage(Handler.java:102) 
            at android.os.Looper.loop(Looper.java:148) 
            at android.app.ActivityThread.main(ActivityThread.java:5417) 
            at java.lang.reflect.Method.invoke(Native Method) 
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 
```