### PR TITLE
Runtime check - Cycle should end even if lookupProvider fails

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/ScopeImpl.java
+++ b/toothpick-runtime/src/main/java/toothpick/ScopeImpl.java
@@ -45,24 +45,24 @@ public class ScopeImpl extends ScopeNode {
 
   @Override
   public <T> T getInstance(Class<T> clazz) {
-    ConfigurationHolder.configuration.checkCyclesStart(clazz, null);
-    T t = lookupProvider(clazz, null).get(this);
-    ConfigurationHolder.configuration.checkCyclesEnd(clazz, null);
-    return t;
+    return getInstance(clazz, null);
   }
 
   @Override
   public <T> T getInstance(Class<T> clazz, String name) {
     ConfigurationHolder.configuration.checkCyclesStart(clazz, name);
-    T t = lookupProvider(clazz, name).get(this);
-    ConfigurationHolder.configuration.checkCyclesEnd(clazz, name);
+    T t;
+    try {
+      t = lookupProvider(clazz, name).get(this);
+    } finally {
+      ConfigurationHolder.configuration.checkCyclesEnd(clazz, name);
+    }
     return t;
   }
 
   @Override
   public <T> Provider<T> getProvider(Class<T> clazz) {
-    InternalProviderImpl<? extends T> provider = lookupProvider(clazz, null);
-    return new ThreadSafeProviderImpl<>(this, provider, false);
+    return getProvider(clazz, null);
   }
 
   @Override
@@ -73,8 +73,7 @@ public class ScopeImpl extends ScopeNode {
 
   @Override
   public <T> Lazy<T> getLazy(Class<T> clazz) {
-    InternalProviderImpl<? extends T> provider = lookupProvider(clazz, null);
-    return new ThreadSafeProviderImpl<>(this, provider, true);
+    return getLazy(clazz, null);
   }
 
   @Override

--- a/toothpick-runtime/src/test/java/toothpick/getInstance/CycleCheckTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/getInstance/CycleCheckTest.java
@@ -11,6 +11,8 @@ import toothpick.config.Module;
 import toothpick.configuration.CyclicDependencyException;
 import toothpick.data.CyclicFoo;
 import toothpick.data.CyclicNamedFoo;
+import toothpick.data.IFoo;
+import toothpick.registries.NoFactoryFoundException;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
@@ -67,5 +69,24 @@ public class CycleCheckTest extends ToothpickBaseTest {
     // Should not crashed
     assertThat(instance2, notNullValue());
     assertThat(instance2.cyclicFoo, sameInstance(instance1));
+  }
+
+  @Test(expected = NoFactoryFoundException.class)
+  public void testCycleDetection_whenGetInstanceFails_shouldCloseCycle() throws Exception {
+    //GIVEN
+    Scope scope = new ScopeImpl("");
+
+    //WHEN
+    try {
+      scope.getInstance(IFoo.class);
+    } catch (NoFactoryFoundException nfe) {
+      // nothing
+    }
+
+    scope.getInstance(IFoo.class);
+
+    //THEN
+    fail("Should throw NoFactoryFoundException as IFoo does not have any implementation bound."
+        + "But It should not throw CyclicDependencyException as it was removed from the stack.");
   }
 }


### PR DESCRIPTION
For this usage, the cycle runtime check would be spoiled.
```java
try {
  scope.getInstance(A.class);
} catch (XXX e) {
  ...
}
```

`A` would stay inside `cycleDetectionStack`, even though the injection for A finished.