### PR TITLE
Singletons not allowed to be bound with RuntimeConfiguration

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/configuration/Configuration.java
+++ b/toothpick-runtime/src/main/java/toothpick/configuration/Configuration.java
@@ -22,7 +22,7 @@ public class Configuration implements RuntimeCheckConfiguration, ReflectionConfi
    * <ul>
    * <li>cycle detection: check that not 2 classes depend on each other. Note that if of them uses a Lazy instance
    * of the other or a Producer, then there is no such cycle.</li>
-   * <li>illegal binding detection: check no scope annotated class is used as the target of a binding.</li>
+   * <li>illegal binding detection: check no scope annotated class (with the exception of Singleton) is used as the target of a binding.</li>
    * </ul>
    *
    * @return a development configuration.

--- a/toothpick-runtime/src/main/java/toothpick/configuration/RuntimeCheckOnConfiguration.java
+++ b/toothpick-runtime/src/main/java/toothpick/configuration/RuntimeCheckOnConfiguration.java
@@ -1,12 +1,13 @@
 package toothpick.configuration;
 
 import java.lang.annotation.Annotation;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
+
+import javax.inject.Singleton;
+
 import toothpick.config.Binding;
 
 import static java.lang.String.format;
@@ -39,6 +40,10 @@ class RuntimeCheckOnConfiguration implements RuntimeCheckConfiguration {
     }
 
     for (Annotation annotation : clazz.getAnnotations()) {
+      if (annotation instanceof Singleton) {
+        continue;
+      }
+
       if (annotation.annotationType().isAnnotationPresent(javax.inject.Scope.class)) {
         throw new IllegalBindingException(format("Class %s cannot be bound. It has an scope annotation", clazz.getName()));
       }

--- a/toothpick-runtime/src/test/java/toothpick/AllBindingsTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/AllBindingsTest.java
@@ -1,8 +1,11 @@
 package toothpick;
 
-import javax.inject.Provider;
 import org.junit.Test;
+
+import javax.inject.Provider;
+
 import toothpick.config.Module;
+import toothpick.configuration.Configuration;
 import toothpick.data.Bar;
 import toothpick.data.CustomScope;
 import toothpick.data.Foo;
@@ -127,6 +130,28 @@ public class AllBindingsTest extends ToothpickBaseTest {
     scope.installModules(new Module() {
       {
         bind(IFooSingleton.class).to(FooSingleton.class);
+      }
+    });
+
+    //WHEN
+    FooSingleton foo = scope.getInstance(FooSingleton.class);
+    FooSingleton foo2 = scope.getInstance(FooSingleton.class);
+
+    //THEN
+    assertThat(foo, notNullValue());
+    assertThat(foo2, sameInstance(foo));
+    assertThat(foo.bar, notNullValue());
+    assertThat(foo.bar, isA(Bar.class));
+  }
+
+  @Test
+  public void bindToClass_shouldCreateInjectedSingletons_whenBoundClassAnnotatedSingletonAndRuntimeCheckOn() throws Exception {
+    //GIVEN
+    Toothpick.setConfiguration(Configuration.forDevelopment());
+    Scope scope = new ScopeImpl("");
+    scope.installModules(new Module() {
+      {
+        bind(FooSingleton.class);
       }
     });
 


### PR DESCRIPTION
It is my understanding from the docs in [Module.java](https://github.com/stephanenicolas/toothpick/blob/6e33843714412565ff010fffbaf8954a69724be0/toothpick/src/main/java/toothpick/config/Module.java) and the test case `bindToClass_shouldCreateInjectedSingletons_whenBoundClassAnnotatedSingleton` that you can bind Singleton's to a scope.

This works with the `RuntimeCheckOffConfiguration` but not the `RuntimeCheckOnConfiguration`

This PR addresses that.

-----

I see that there are a number of failing tests related to this change.
I'm happy to address those once you confirm my interpretation of @Singleton is correct and/or that the javadocs are actually up to date (I suspect they are not).