### PR TITLE
Solves issue 118: support custom annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Release version 1.0.0 (to be released)
 
 * Solves issue [#117](https://github.com/stephanenicolas/toothpick/issues/117) Factory code generator should strip the generic part of dependencies.
+* Solves issue [#118](https://github.com/stephanenicolas/toothpick/issues/118) Support custom annotations.
 
 ## Release version 1.0.0-RC10 (Sep 29th 2016)
 

--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
@@ -49,7 +49,7 @@ public class MemberInjectorProcessor extends ToothpickProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    readProcessorOptions();
+    readCommonProcessorOptions();
     findAndParseTargets(roundEnv);
 
     if (!roundEnv.processingOver()) {

--- a/toothpick-compiler/src/test/java/toothpick/compiler/factory/ProcessorTestUtilities.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/factory/ProcessorTestUtilities.java
@@ -30,4 +30,15 @@ final class ProcessorTestUtilities {
     factoryProcessor.setToothpickExcludeFilters(toothpickExcludeFilters);
     return Arrays.asList(factoryProcessor);
   }
+
+  static Iterable<? extends Processor> factoryProcessorsWithAdditionalTypes(String... types) {
+    FactoryProcessor factoryProcessor = new FactoryProcessor();
+    for (String type : types) {
+      factoryProcessor.addSupportedAnnotationType(type);
+    }
+
+    return Arrays.asList(factoryProcessor);
+  }
+
+
 }

--- a/toothpick-runtime/build.gradle
+++ b/toothpick-runtime/build.gradle
@@ -17,7 +17,8 @@ dependencies {
 
 compileTestJava {
   doFirst {
-    options.compilerArgs = ['-Atoothpick_registry_package_name=toothpick.test',]
+    options.compilerArgs = ['-Atoothpick_registry_package_name=toothpick.test',
+                            '-Atoothpick_annotations=toothpick.data.CustomScope',]
   }
 }
 

--- a/toothpick-runtime/src/test/java/toothpick/data/FooCustomScope.java
+++ b/toothpick-runtime/src/test/java/toothpick/data/FooCustomScope.java
@@ -1,0 +1,5 @@
+package toothpick.data;
+
+@CustomScope
+public class FooCustomScope implements IFooSingleton {
+}

--- a/toothpick-runtime/src/test/java/toothpick/scoping/ScopingTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/scoping/ScopingTest.java
@@ -11,6 +11,7 @@ import toothpick.data.BarChild;
 import toothpick.data.CustomScope;
 import toothpick.data.Foo;
 import toothpick.data.FooChildWithoutInjectedFields;
+import toothpick.data.FooCustomScope;
 import toothpick.data.FooProviderAnnotatedProvidesSingleton;
 import toothpick.data.FooProviderAnnotatedSingletonImpl;
 import toothpick.data.FooSingleton;
@@ -418,7 +419,7 @@ public class ScopingTest extends ToothpickBaseTest {
   }
 
   @Test
-  public void binding_shouldCreateAnnotatedClassInScopeBoundToScopeAnnotation_whenParentScopeIsBoundToScopeAnnotation() throws Exception {
+  public void binding_shouldCreateAnnotatedClassInScopeBoundToScopeAnnotationViaProvider_whenParentScopeIsBoundToScopeAnnotation() throws Exception {
     //GIVEN
     Toothpick.setConfiguration(forDevelopment());
     Scope scopeParent = Toothpick.openScope(CustomScope.class);
@@ -427,6 +428,21 @@ public class ScopingTest extends ToothpickBaseTest {
     //WHEN
     FooProviderAnnotatedProvidesSingleton instanceInParent = scopeParent.getInstance(FooProviderAnnotatedProvidesSingleton.class);
     FooProviderAnnotatedProvidesSingleton instanceInChild = scope1.getInstance(FooProviderAnnotatedProvidesSingleton.class);
+
+    //THEN
+    assertThat(instanceInParent, sameInstance(instanceInChild));
+  }
+
+  @Test
+  public void binding_shouldCreateAnnotatedClassInScopeBoundToScopeAnnotationViaFactory_whenParentScopeIsBoundToScopeAnnotation() throws Exception {
+    //GIVEN
+    Toothpick.setConfiguration(forDevelopment());
+    Scope scopeParent = Toothpick.openScope(CustomScope.class);
+    Scope scope1 = Toothpick.openScopes(CustomScope.class, "child");
+
+    //WHEN
+    FooCustomScope instanceInParent = scopeParent.getInstance(FooCustomScope.class);
+    FooCustomScope instanceInChild = scope1.getInstance(FooCustomScope.class);
 
     //THEN
     assertThat(instanceInParent, sameInstance(instanceInChild));


### PR DESCRIPTION
Solves #118 
TODO : update the wiki. A new option has been added : `toothpick_annotations` to list the custom scope annotation classes that TP should take into account.