### PR TITLE
solves issue #117: Make generic usage more robust with Lazy / Provider

### DIFF
--- a/toothpick-compiler/src/main/java/toothpick/compiler/common/ToothpickProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/common/ToothpickProcessor.java
@@ -271,6 +271,19 @@ public abstract class ToothpickProcessor extends AbstractProcessor {
       }
       return false;
     }
+
+    TypeMirror firstParameterTypeMirror = declaredType.getTypeArguments().get(0);
+    if(firstParameterTypeMirror.getKind() == TypeKind.DECLARED) {
+      int size = ((DeclaredType) firstParameterTypeMirror).getTypeArguments().size();
+      if(size != 0) {
+        Element enclosingElement = element.getEnclosingElement();
+        error(element, "Lazy/Provider %s is not a valid in %s. Lazy/Provider cannot be used on generic types.",
+            element.getSimpleName(), //
+            enclosingElement.getSimpleName());
+        return false;
+      }
+    }
+
     return true;
   }
 
@@ -306,7 +319,7 @@ public abstract class ToothpickProcessor extends AbstractProcessor {
   protected TypeElement getInjectedType(VariableElement variableElement) {
     final TypeElement fieldType;
     if (getParamInjectionTargetKind(variableElement) == ParamInjectionTarget.Kind.INSTANCE) {
-      fieldType = (TypeElement) typeUtils.asElement(variableElement.asType());
+      fieldType = (TypeElement) typeUtils.asElement(typeUtils.erasure(variableElement.asType()));
     } else {
       fieldType = getKindParameter(variableElement);
     }
@@ -459,7 +472,7 @@ public abstract class ToothpickProcessor extends AbstractProcessor {
   private TypeElement getKindParameter(Element element) {
     TypeMirror elementTypeMirror = element.asType();
     TypeMirror firstParameterTypeMirror = ((DeclaredType) elementTypeMirror).getTypeArguments().get(0);
-    return (TypeElement) typeUtils.asElement(firstParameterTypeMirror);
+    return (TypeElement) typeUtils.asElement(typeUtils.erasure(firstParameterTypeMirror));
   }
 
   protected boolean isNonStaticInnerClass(TypeElement typeElement) {

--- a/toothpick-compiler/src/main/java/toothpick/compiler/common/generators/CodeGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/common/generators/CodeGenerator.java
@@ -6,6 +6,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Types;
 import toothpick.compiler.common.generators.targets.ParamInjectionTarget;
 
 /**
@@ -14,6 +15,11 @@ import toothpick.compiler.common.generators.targets.ParamInjectionTarget;
 public abstract class CodeGenerator {
 
   protected static final String LINE_SEPARATOR = System.getProperty("line.separator");
+  protected Types typeUtil;
+
+  public CodeGenerator(Types typeUtil) {
+    this.typeUtil = typeUtil;
+  }
 
   /**
    * Creates all java code.
@@ -52,10 +58,10 @@ public abstract class CodeGenerator {
 
   protected TypeName getParamType(ParamInjectionTarget paramInjectionTarget) {
     if (paramInjectionTarget.kind == ParamInjectionTarget.Kind.INSTANCE) {
-      return TypeName.get(paramInjectionTarget.memberClass.asType());
+      return TypeName.get(typeUtil.erasure(paramInjectionTarget.memberClass.asType()));
     } else {
       return ParameterizedTypeName.get(ClassName.get(paramInjectionTarget.memberClass),
-          ClassName.get(paramInjectionTarget.kindParamClass));
+          ClassName.get(typeUtil.erasure(paramInjectionTarget.kindParamClass.asType())));
     }
   }
 

--- a/toothpick-compiler/src/main/java/toothpick/compiler/factory/FactoryProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/factory/FactoryProcessor.java
@@ -84,7 +84,7 @@ public class FactoryProcessor extends ToothpickProcessor {
 
     for (Map.Entry<TypeElement, ConstructorInjectionTarget> entry : mapTypeElementToConstructorInjectionTarget.entrySet()) {
       ConstructorInjectionTarget constructorInjectionTarget = entry.getValue();
-      FactoryGenerator factoryGenerator = new FactoryGenerator(constructorInjectionTarget);
+      FactoryGenerator factoryGenerator = new FactoryGenerator(constructorInjectionTarget, typeUtils);
       TypeElement typeElement = entry.getKey();
       String fileDescription = format("Factory for type %s", typeElement);
       boolean success = writeToFile(factoryGenerator, fileDescription, typeElement);
@@ -99,7 +99,7 @@ public class FactoryProcessor extends ToothpickProcessor {
       RegistryInjectionTarget registryInjectionTarget =
           new RegistryInjectionTarget(Factory.class, AbstractFactoryRegistry.class, toothpickRegistryPackageName,
               toothpickRegistryChildrenPackageNameList, elementsWithFactoryCreated);
-      RegistryGenerator registryGenerator = new RegistryGenerator(registryInjectionTarget);
+      RegistryGenerator registryGenerator = new RegistryGenerator(registryInjectionTarget, typeUtils);
 
       String fileDescription = "Factory registry";
       Element[] allTypes = elementsWithFactoryCreated.toArray(new Element[elementsWithFactoryCreated.size()]);

--- a/toothpick-compiler/src/main/java/toothpick/compiler/factory/generators/FactoryGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/factory/generators/FactoryGenerator.java
@@ -1,5 +1,6 @@
 package toothpick.compiler.factory.generators;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -9,6 +10,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.util.Types;
 import toothpick.Factory;
 import toothpick.MemberInjector;
 import toothpick.Scope;
@@ -28,7 +30,8 @@ public class FactoryGenerator extends CodeGenerator {
 
   private ConstructorInjectionTarget constructorInjectionTarget;
 
-  public FactoryGenerator(ConstructorInjectionTarget constructorInjectionTarget) {
+  public FactoryGenerator(ConstructorInjectionTarget constructorInjectionTarget, Types types) {
+    super(types);
     this.constructorInjectionTarget = constructorInjectionTarget;
   }
 

--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/MemberInjectorProcessor.java
@@ -67,7 +67,11 @@ public class MemberInjectorProcessor extends ToothpickProcessor {
       List<MethodInjectionTarget> methodInjectionTargetList = mapTypeElementToMethodInjectorTargetList.get(typeElement);
       TypeElement superClassThatNeedsInjection = mapTypeElementToSuperTypeElementThatNeedsInjection.get(typeElement);
       MemberInjectorGenerator memberInjectorGenerator =
-          new MemberInjectorGenerator(typeElement, superClassThatNeedsInjection, fieldInjectionTargetList, methodInjectionTargetList);
+          new MemberInjectorGenerator(typeElement, //
+              superClassThatNeedsInjection, //
+              fieldInjectionTargetList, //
+              methodInjectionTargetList, //
+              typeUtils);
       String fileDescription = String.format("MemberInjector for type %s", typeElement);
       boolean success = writeToFile(memberInjectorGenerator, fileDescription, typeElement);
       if (success) {
@@ -80,7 +84,7 @@ public class MemberInjectorProcessor extends ToothpickProcessor {
       RegistryInjectionTarget registryInjectionTarget =
           new RegistryInjectionTarget(MemberInjector.class, AbstractMemberInjectorRegistry.class, toothpickRegistryPackageName,
               toothpickRegistryChildrenPackageNameList, elementsWithMemberInjectorCreated);
-      RegistryGenerator registryGenerator = new RegistryGenerator(registryInjectionTarget);
+      RegistryGenerator registryGenerator = new RegistryGenerator(registryInjectionTarget, typeUtils);
 
       String fileDescription = "MemberInjector registry";
       Element[] allTypes = elementsWithMemberInjectorCreated.toArray(new Element[elementsWithMemberInjectorCreated.size()]);

--- a/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/memberinjector/generators/MemberInjectorGenerator.java
@@ -11,6 +11,7 @@ import com.squareup.javapoet.TypeSpec;
 import java.util.List;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Types;
 import toothpick.MemberInjector;
 import toothpick.Scope;
 import toothpick.compiler.common.generators.CodeGenerator;
@@ -33,7 +34,9 @@ public class MemberInjectorGenerator extends CodeGenerator {
   private List<MethodInjectionTarget> methodInjectionTargetList;
 
   public MemberInjectorGenerator(TypeElement targetClass, TypeElement superClassThatNeedsInjection,
-      List<FieldInjectionTarget> fieldInjectionTargetList, List<MethodInjectionTarget> methodInjectionTargetList) {
+      List<FieldInjectionTarget> fieldInjectionTargetList, List<MethodInjectionTarget> methodInjectionTargetList,
+      Types types) {
+    super(types);
     this.targetClass = targetClass;
     this.superClassThatNeedsInjection = superClassThatNeedsInjection;
     this.fieldInjectionTargetList = fieldInjectionTargetList;

--- a/toothpick-compiler/src/main/java/toothpick/compiler/registry/generators/RegistryGenerator.java
+++ b/toothpick-compiler/src/main/java/toothpick/compiler/registry/generators/RegistryGenerator.java
@@ -7,6 +7,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.TypeVariableName;
+import javax.lang.model.util.Types;
 import toothpick.compiler.common.generators.CodeGenerator;
 import toothpick.compiler.registry.targets.RegistryInjectionTarget;
 import toothpick.registries.FactoryRegistry;
@@ -31,7 +32,8 @@ public class RegistryGenerator extends CodeGenerator {
 
   private RegistryInjectionTarget registryInjectionTarget;
 
-  public RegistryGenerator(RegistryInjectionTarget registryInjectionTarget) {
+  public RegistryGenerator(RegistryInjectionTarget registryInjectionTarget, Types types) {
+    super(types);
     this.registryInjectionTarget = registryInjectionTarget;
   }
 

--- a/toothpick-compiler/src/test/java/toothpick/compiler/factory/FactoryTest.java
+++ b/toothpick-compiler/src/test/java/toothpick/compiler/factory/FactoryTest.java
@@ -444,6 +444,93 @@ public class FactoryTest extends BaseFactoryTest {
   }
 
   @Test
+  public void testNonEmptyConstructorWithGenerics() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.TestNonEmptyConstructor", Joiner.on('\n').join(//
+        "package test;", //
+        "import java.util.List;", //
+        "import javax.inject.Inject;", //
+        "public class TestNonEmptyConstructor {", //
+        "  @Inject public TestNonEmptyConstructor(List<String> str) {}", //
+        "}" //
+    ));
+
+    JavaFileObject expectedSource = JavaFileObjects.forSourceString("test/TestNonEmptyConstructor$$Factory", Joiner.on('\n').join(//
+        "package test;", //
+        "import java.lang.Override;", //
+        "import java.util.List;", //
+        "import toothpick.Factory;", //
+        "import toothpick.Scope;", //
+        "", //
+        "public final class TestNonEmptyConstructor$$Factory implements Factory<TestNonEmptyConstructor> {", //
+        "  @Override", //
+        "  public TestNonEmptyConstructor createInstance(Scope scope) {", //
+        "    scope = getTargetScope(scope);", //
+        "    List param1 = scope.getInstance(List.class);", //
+        "    TestNonEmptyConstructor testNonEmptyConstructor = new TestNonEmptyConstructor(param1);", //
+        "    return testNonEmptyConstructor;", //
+        "  }", //
+        "  @Override", //
+        "  public Scope getTargetScope(Scope scope) {", //
+        "    return scope;", //
+        "  }", //
+        "  @Override", //
+        "  public boolean hasScopeAnnotation() {", //
+        "    return false;", //
+        "  }", //
+        "  @Override", //
+        "  public boolean hasProvidesSingletonInScopeAnnotation() {", //
+        "    return false;", //
+        "  }", //
+        "}" //
+    ));
+
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(ProcessorTestUtilities.factoryProcessors())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expectedSource);
+  }
+
+  @Test
+  public void testNonEmptyConstructorWithLazyAndGenerics_shouldFail() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.TestNonEmptyConstructor", Joiner.on('\n').join(//
+        "package test;", //
+        "import java.util.List;", //
+        "import javax.inject.Inject;", //
+        "import toothpick.Lazy;", //
+        "public class TestNonEmptyConstructor {", //
+        "  @Inject public TestNonEmptyConstructor(Lazy<List<String>> str) {}", //
+        "}" //
+    ));
+
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(ProcessorTestUtilities.factoryProcessors())
+        .failsToCompile()
+        .withErrorContaining("Lazy/Provider str is not a valid in <init>. Lazy/Provider cannot be used on generic types.");
+  }
+
+  @Test
+  public void testNonEmptyConstructorWithProviderAndGenerics_shouldFail() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.TestNonEmptyConstructor", Joiner.on('\n').join(//
+        "package test;", //
+        "import java.util.List;", //
+        "import javax.inject.Inject;", //
+        "import javax.inject.Provider;", //
+        "public class TestNonEmptyConstructor {", //
+        "  @Inject public TestNonEmptyConstructor(Provider<List<String>> str) {}", //
+        "}" //
+    ));
+
+    assert_().about(javaSource())
+        .that(source)
+        .processedWith(ProcessorTestUtilities.factoryProcessors())
+        .failsToCompile()
+        .withErrorContaining("Lazy/Provider str is not a valid in <init>. Lazy/Provider cannot be used on generic types.");
+  }
+
+  @Test
   public void testAbstractClassWithInjectedConstructor() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.TestInvalidClassConstructor", Joiner.on('\n').join(//
         "package test;", //


### PR DESCRIPTION
Solves #117 . This is a tricky PR. 
@dlemures look at the tests, TP allows some limited usages of generics, but not all things are possible.

if we have a class 
```java
class Foo<T> {..}
```

then `Lazy<Foo>` is allowed but not `Lazy<Foo<String>>`, as there was no way to generate the code that would create the lazy and make it compile.

The problem is that `getLazy(Foo.class)` cannot generate something that would be a valid `Foo<X>`, we would need to add more type parameters to `getLazy` and we don't want that as the possibilities are infinite (e.g. `Foo<X<Y,Z>, W>`, we would need 4 more params here...).