### PR TITLE
Making scope reference from lazies and providers a weak reference

### DIFF
--- a/toothpick-runtime/src/test/java/toothpick/inject/lazy/InjectionOfLazyProviderTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/inject/lazy/InjectionOfLazyProviderTest.java
@@ -63,4 +63,19 @@ public class InjectionOfLazyProviderTest extends ToothpickBaseTest {
     assertThat(bar2, isA(Bar.class));
     assertThat(bar2, sameInstance(bar1));
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void testLazyAfterClosingScope() throws Exception {
+    //GIVEN
+    String scopeName = "";
+    FooWithLazy fooWithLazy = new FooWithLazy();
+
+    //WHEN
+    Toothpick.inject(fooWithLazy, Toothpick.openScope(scopeName));
+    Toothpick.closeScope(scopeName);
+    System.gc();
+
+    //THEN
+    fooWithLazy.bar.get(); // should crash
+  }
 }


### PR DESCRIPTION
To avoid having lazies or providers that leaks the contexts after being closed.

So:
If you try to create the instance after the scope has been closed, we fail.