### PR TITLE
Adding check to ensure that scopes are not used after being closed

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/ScopeImpl.java
+++ b/toothpick-runtime/src/main/java/toothpick/ScopeImpl.java
@@ -50,6 +50,7 @@ public class ScopeImpl extends ScopeNode {
 
   @Override
   public <T> T getInstance(Class<T> clazz, String name) {
+    crashIfClosed();
     ConfigurationHolder.configuration.checkCyclesStart(clazz, name);
     T t;
     try {
@@ -67,8 +68,8 @@ public class ScopeImpl extends ScopeNode {
 
   @Override
   public <T> Provider<T> getProvider(Class<T> clazz, String name) {
-    InternalProviderImpl<? extends T> provider = lookupProvider(clazz, name);
-    return new ThreadSafeProviderImpl<>(this, provider, false);
+    crashIfClosed();
+    return new ThreadSafeProviderImpl<>(this, clazz, name, false);
   }
 
   @Override
@@ -78,8 +79,8 @@ public class ScopeImpl extends ScopeNode {
 
   @Override
   public <T> Lazy<T> getLazy(Class<T> clazz, String name) {
-    InternalProviderImpl<? extends T> provider = lookupProvider(clazz, name);
-    return new ThreadSafeProviderImpl<>(this, provider, true);
+    crashIfClosed();
+    return new ThreadSafeProviderImpl<>(this, clazz, name, true);
   }
 
   @Override
@@ -500,6 +501,13 @@ public class ScopeImpl extends ScopeNode {
       } else {
         return previous;
       }
+    }
+  }
+
+  private void crashIfClosed() {
+    if (!isOpen) {
+      throw new IllegalStateException(String.format("The scope with name %s has been already closed."
+          + " It is not possible to use it to create new instances.", name));
     }
   }
 

--- a/toothpick-runtime/src/main/java/toothpick/ScopeNode.java
+++ b/toothpick-runtime/src/main/java/toothpick/ScopeNode.java
@@ -78,6 +78,7 @@ public abstract class ScopeNode implements Scope {
   //as setting the parent is called only once when creating a node
   protected final List<ScopeNode> parentScopes = new CopyOnWriteArrayList<>();
   protected Object name;
+  protected boolean isOpen = true;
   //same here for lock free access
   protected final Set<Class<? extends Annotation>> scopeAnnotationClasses = new CopyOnWriteArraySet<>();
 
@@ -259,6 +260,10 @@ public abstract class ScopeNode implements Scope {
     childrenScopes.remove(child.getName());
     //make the ex-child a new root.
     child.parentScopes.clear();
+  }
+
+  void close() {
+    isOpen = false;
   }
 
   private void checkIsAnnotationScope(Class<? extends Annotation> scopeAnnotationClass) {

--- a/toothpick-runtime/src/main/java/toothpick/ThreadSafeProviderImpl.java
+++ b/toothpick-runtime/src/main/java/toothpick/ThreadSafeProviderImpl.java
@@ -11,12 +11,14 @@ import javax.inject.Provider;
 public class ThreadSafeProviderImpl<T> implements Provider<T>, Lazy<T> {
   private volatile T instance;
   private WeakReference<Scope> scope;
-  private InternalProviderImpl<? extends T> providerInstance;
+  private Class<T> clazz;
+  private String name;
   private boolean isLazy;
 
-  public ThreadSafeProviderImpl(Scope scope, InternalProviderImpl<? extends T> providerInstance, boolean isLazy) {
+  public ThreadSafeProviderImpl(Scope scope, Class<T> clazz, String name, boolean isLazy) {
     this.scope = new WeakReference<>(scope);
-    this.providerInstance = providerInstance;
+    this.clazz = clazz;
+    this.name = name;
     this.isLazy = isLazy;
   }
 
@@ -34,13 +36,12 @@ public class ThreadSafeProviderImpl<T> implements Provider<T>, Lazy<T> {
       if (isLazy) {
         //DCL
         if (instance == null) {
-          instance = providerInstance.get(getScope());
-          //gc
-          providerInstance = null;
+          instance = getScope().getInstance(clazz, name);
+          scope.clear();
         }
         return instance;
       }
-      return providerInstance.get(getScope());
+      return getScope().getInstance(clazz, name);
     }
   }
 

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -1,5 +1,6 @@
 package toothpick;
 
+import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 import toothpick.configuration.Configuration;
 import toothpick.configuration.ConfigurationHolder;
@@ -121,7 +122,9 @@ public final class Toothpick {
    */
 
   public static void reset() {
-    MAP_KEY_TO_SCOPE.clear();
+    for (Object name : new ArrayList<>(MAP_KEY_TO_SCOPE.keySet())) {
+      closeScope(name);
+    }
     ConfigurationHolder.configuration.onScopeForestReset();
     ScopeImpl.reset();
   }
@@ -147,6 +150,7 @@ public final class Toothpick {
    */
   private static void removeScopeAndChildrenFromMap(ScopeNode scope) {
     MAP_KEY_TO_SCOPE.remove(scope.getName());
+    scope.close();
     for (ScopeNode childScope : scope.childrenScopes.values()) {
       removeScopeAndChildrenFromMap(childScope);
     }

--- a/toothpick-runtime/src/test/java/toothpick/ScopeImplTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ScopeImplTest.java
@@ -1,5 +1,6 @@
 package toothpick;
 
+import javax.inject.Provider;
 import org.junit.Test;
 import toothpick.config.Module;
 import toothpick.data.Bar;
@@ -108,6 +109,94 @@ public class ScopeImplTest extends ToothpickBaseTest {
 
     //WHEN
     new ScopeImpl("").toProvider(null);
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getInstance_shouldFail_whenScopeIsClosed() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+
+    //WHEN
+    scope.close();
+    scope.getInstance(Foo.class);
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getLazy_shouldFail_whenScopeIsClosed() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+
+    //WHEN
+    scope.close();
+    scope.getLazy(Foo.class);
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void getProvider_shouldFail_whenScopeIsClosed() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+
+    //WHEN
+    scope.close();
+    scope.getProvider(Foo.class);
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void lazyGet_shouldFail_whenScopeIsClosed() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+    Lazy<Foo> lazy = scope.getLazy(Foo.class);
+
+    //WHEN
+    scope.close();
+    lazy.get();
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void providerGet_shouldFail_whenScopeIsClosed() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+    Provider<Foo> provider = scope.getProvider(Foo.class);
+
+    //WHEN
+    scope.close();
+    provider.get();
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void lazyGet_shouldFail_whenScopeIsClosed_andThereAreNoDependencies() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+    Lazy<Bar> lazy = scope.getLazy(Bar.class);
+
+    //WHEN
+    scope.close();
+    lazy.get();
+
+    //THEN
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void providerGet_shouldFail_whenScopeIsClosed_andThereAreNoDependencies() {
+    //GIVEN
+    ScopeImpl scope = new ScopeImpl("");
+    Provider<Bar> provider = scope.getProvider(Bar.class);
+
+    //WHEN
+    scope.close();
+    provider.get();
 
     //THEN
   }

--- a/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
@@ -55,6 +55,17 @@ public class ToothpickTest extends ToothpickBaseTest {
     assertThat(scope.getParentScope(), sameInstance(scopeParent));
   }
 
+  @Test
+  public void createScope_shouldMarkThisScopeAsOpen() throws Exception {
+    //GIVEN
+
+    //WHEN
+    ScopeImpl scope = (ScopeImpl) Toothpick.openScope("foo");
+
+    //THEN
+    assertThat(scope.isOpen, is(true));
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void openScopes_shouldFail_whenScopeNamesAreNull() throws Exception {
     //GIVEN
@@ -63,7 +74,6 @@ public class ToothpickTest extends ToothpickBaseTest {
     Toothpick.openScopes((Object[]) null);
 
     //THEN
-    fail("Shoudl ahve thrown an exception");
   }
 
   @Test
@@ -97,6 +107,18 @@ public class ToothpickTest extends ToothpickBaseTest {
     assertThat(scopeAfterReset, not(sameInstance(scope)));
   }
 
+  @Test
+  public void closeScope_shouldMarkThisScopeAsClosed() throws Exception {
+    //GIVEN
+    ScopeImpl scope = (ScopeImpl) Toothpick.openScope("foo");
+
+    //WHEN
+    Toothpick.closeScope("foo");
+
+    //THEN
+    assertThat(scope.isOpen, is(false));
+  }
+
   @Test(expected = MultipleRootException.class)
   public void openingAClosedChildScope_shouldThrowAnException_whenConfigurationPreventsMultipleRootScopes() throws Exception {
     //GIVEN
@@ -108,7 +130,6 @@ public class ToothpickTest extends ToothpickBaseTest {
     Toothpick.openScope("bar");
 
     //THEN
-    fail("Should throw an exception");
   }
 
   @Test(expected = MultipleRootException.class)
@@ -121,7 +142,6 @@ public class ToothpickTest extends ToothpickBaseTest {
     Toothpick.openScope("bar");
 
     //THEN
-    fail("Should throw an exception");
   }
 
   @Test
@@ -197,7 +217,6 @@ public class ToothpickTest extends ToothpickBaseTest {
     constructor.newInstance();
 
     //THEN
-    fail("default constructor should not be invokable even via reflection");
   }
 
   @After


### PR DESCRIPTION
Issue: https://github.com/stephanenicolas/toothpick/issues/178

Adding check to ensure that scopes are not used after being closed.