### PR TITLE
Issue-176: Use standard javax annotation by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ subprojects { project ->
 }
 
 ext.deps = [// Common
+            inject              : 'javax.inject:javax.inject:1',
 
             // Compiler
             javapoet            : 'com.squareup:javapoet:1.4.0',

--- a/smoothie/build.gradle
+++ b/smoothie/build.gradle
@@ -23,7 +23,7 @@ configurations {
 dependencies {
   compile project(':toothpick')
   processor  project(':toothpick-compiler')
-  compile project(':toothpick-javax-annotations')
+  compile deps.inject
   compile deps.android
   optional deps.supportv4
 

--- a/toothpick-compiler/build.gradle
+++ b/toothpick-compiler/build.gradle
@@ -5,7 +5,7 @@ targetCompatibility = 1.7
 
 dependencies {
   compile project(':toothpick-generated-core')
-  compile project(':toothpick-javax-annotations')
+  compile deps.inject
   compile deps.javapoet
 
   testCompile deps.junit

--- a/toothpick-sample/build.gradle
+++ b/toothpick-sample/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   compile project(':toothpick')
   compile project(':toothpick-runtime')
   compile project(':toothpick-compiler')
-  compile project(':toothpick-javax-annotations')
+  compile deps.inject
 
   testCompile project(':toothpick-testing')
   testCompile deps.easymock

--- a/toothpick/build.gradle
+++ b/toothpick/build.gradle
@@ -4,7 +4,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-  compile project(':toothpick-javax-annotations')
+  compile deps.inject
 
   testCompile deps.junit
 }


### PR DESCRIPTION
Issue: https://github.com/stephanenicolas/toothpick/issues/176

Tested in MGA: 
* Using default javax for testing
* Using TP javax for production, replacing with TP javax annotations