### PR TITLE
Auto close activities scopes and introduce close listeners

### DIFF
--- a/smoothie-sample/src/main/java/com/example/smoothie/RxMVPActivity.java
+++ b/smoothie-sample/src/main/java/com/example/smoothie/RxMVPActivity.java
@@ -43,7 +43,9 @@ public class RxMVPActivity extends Activity {
     setContentView(R.layout.simple_activity);
     ButterKnife.bind(this);
     title.setText("MVP");
-    subscription = rxPresenter.subscribe(aLong -> subTitle.setText(String.valueOf(aLong)));
+    subscription = rxPresenter
+        .getTimeObservable()
+        .subscribe(aLong -> subTitle.setText(String.valueOf(aLong)));
     button.setVisibility(View.GONE);
   }
 

--- a/smoothie-sample/src/main/java/com/example/smoothie/RxMVPActivity.java
+++ b/smoothie-sample/src/main/java/com/example/smoothie/RxMVPActivity.java
@@ -18,6 +18,9 @@ import toothpick.Scope;
 import toothpick.Toothpick;
 import toothpick.smoothie.module.SmoothieActivityModule;
 
+import static toothpick.Toothpick.openScopes;
+import static toothpick.smoothie.module.Smoothie.autoCloseActivityScopeAndParentScope;
+
 public class RxMVPActivity extends Activity {
 
   public static final Class PRESENTER_SCOPE = Presenter.class;
@@ -29,10 +32,11 @@ public class RxMVPActivity extends Activity {
   @BindView(R.id.hello) Button button;
   private Subscription subscription;
 
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    scope = Toothpick.openScopes(getApplication(), PRESENTER_SCOPE, this);
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    scope = openScopes(getApplication(), PRESENTER_SCOPE, this);
     scope.installModules(new SmoothieActivityModule(this));
+    autoCloseActivityScopeAndParentScope(this);
+
     super.onCreate(savedInstanceState);
     Toothpick.inject(this, scope);
 
@@ -45,19 +49,11 @@ public class RxMVPActivity extends Activity {
 
   @Override
   protected void onDestroy() {
-    Toothpick.closeScope(this);
     subscription.unsubscribe();
-    if (isFinishing()) {
-      //when we leave the presenter flow,
-      //we close its scope
-      rxPresenter.stop();
-      Toothpick.closeScope(PRESENTER_SCOPE);
-    }
     super.onDestroy();
   }
 
-  @javax.inject.Scope
-  @Target(ElementType.TYPE)
-  @Retention(RetentionPolicy.RUNTIME)
-  public @interface Presenter {}
+  @javax.inject.Scope @Target(ElementType.TYPE) @Retention(RetentionPolicy.RUNTIME)
+  public @interface Presenter {
+  }
 }

--- a/smoothie-sample/src/main/java/com/example/smoothie/deps/RxPresenter.java
+++ b/smoothie-sample/src/main/java/com/example/smoothie/deps/RxPresenter.java
@@ -14,7 +14,6 @@ import rx.schedulers.Schedulers;
 public class RxPresenter {
 
   private final ConnectableObservable<Long> timeObservable;
-  private final Subscription connect;
 
   @Inject
   public RxPresenter() {
@@ -22,14 +21,12 @@ public class RxPresenter {
         .subscribeOn(Schedulers.newThread()) //
         .observeOn(AndroidSchedulers.mainThread()) //
         .publish();
-    connect = timeObservable.connect();
+    //no need to hold the subscription,
+    // the presenter will just be garbage collected
+    timeObservable.connect();
   }
 
   public Subscription subscribe(Action1<? super Long> action) {
     return timeObservable.subscribe(action);
-  }
-
-  public void stop() {
-    connect.unsubscribe();
   }
 }

--- a/smoothie-sample/src/main/java/com/example/smoothie/deps/RxPresenter.java
+++ b/smoothie-sample/src/main/java/com/example/smoothie/deps/RxPresenter.java
@@ -26,7 +26,7 @@ public class RxPresenter {
     timeObservable.connect();
   }
 
-  public Subscription subscribe(Action1<? super Long> action) {
-    return timeObservable.subscribe(action);
+  public Observable<Long> getTimeObservable() {
+    return timeObservable;
   }
 }

--- a/smoothie/build.gradle
+++ b/smoothie/build.gradle
@@ -21,7 +21,7 @@ configurations {
 }
 
 dependencies {
-  compile project(':toothpick')
+  compile project(':toothpick-runtime')
   processor  project(':toothpick-compiler')
   compile deps.inject
   optional deps.android

--- a/smoothie/src/main/java/toothpick/smoothie/module/Smoothie.java
+++ b/smoothie/src/main/java/toothpick/smoothie/module/Smoothie.java
@@ -1,0 +1,97 @@
+package toothpick.smoothie.module;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import toothpick.Scope;
+import toothpick.Toothpick;
+
+import static toothpick.Toothpick.closeScope;
+import static toothpick.Toothpick.openScope;
+
+public class Smoothie {
+
+  private Smoothie() {
+  }
+
+  public static void autoCloseActivityScope(Activity activity) {
+    Application application = activity.getApplication();
+    application.registerActivityLifecycleCallbacks(
+        new AutoCloseActivityLifecycleCallbacks(activity));
+  }
+
+  public static void autoCloseActivityScopes(Application application) {
+    application.registerActivityLifecycleCallbacks(new AutoCloseActivitiesLifecycleCallbacks());
+  }
+
+  public static void autoCloseActivityScopeAndParentScope(Activity activity) {
+    Application application = activity.getApplication();
+    application.registerActivityLifecycleCallbacks(
+        new AutoCloseActivityParentLifecycleCallbacks(activity));
+  }
+
+  private static class AutoCloseActivityLifecycleCallbacks extends DefaultLifecycleCallbacks {
+    private Activity targetActivity;
+
+    public AutoCloseActivityLifecycleCallbacks(Activity activity) {
+      targetActivity = activity;
+    }
+
+    @Override public void onActivityDestroyed(Activity activity) {
+      if (activity == targetActivity) {
+        closeScope(activity);
+      }
+      final Application application = activity.getApplication();
+      application.unregisterActivityLifecycleCallbacks(this);
+    }
+  }
+
+  private static class AutoCloseActivityParentLifecycleCallbacks extends DefaultLifecycleCallbacks {
+    private Activity targetActivity;
+
+    public AutoCloseActivityParentLifecycleCallbacks(Activity activity) {
+      targetActivity = activity;
+    }
+
+    @Override public void onActivityDestroyed(Activity activity) {
+      if (activity == targetActivity) {
+        closeScope(activity);
+        if(activity.isFinishing()) {
+          final Scope parentScope = openScope(activity).getParentScope();
+          closeScope(parentScope.getName());
+        }
+      }
+      final Application application = activity.getApplication();
+      application.unregisterActivityLifecycleCallbacks(this);
+    }
+  }
+
+  private static class AutoCloseActivitiesLifecycleCallbacks extends DefaultLifecycleCallbacks {
+    @Override public void onActivityDestroyed(Activity activity) {
+      closeScope(activity);
+    }
+  }
+
+  private static class DefaultLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
+    @Override public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+    }
+
+    @Override public void onActivityStarted(Activity activity) {
+    }
+
+    @Override public void onActivityResumed(Activity activity) {
+    }
+
+    @Override public void onActivityPaused(Activity activity) {
+    }
+
+    @Override public void onActivityStopped(Activity activity) {
+    }
+
+    @Override public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+    }
+
+    @Override public void onActivityDestroyed(Activity activity) {
+    }
+  }
+}

--- a/toothpick-runtime/src/main/java/toothpick/ScopeNode.java
+++ b/toothpick-runtime/src/main/java/toothpick/ScopeNode.java
@@ -81,6 +81,7 @@ public abstract class ScopeNode implements Scope {
   protected boolean isOpen = true;
   //same here for lock free access
   protected final Set<Class<? extends Annotation>> scopeAnnotationClasses = new CopyOnWriteArraySet<>();
+  private ScopeClosedListener closeListener;
 
   public ScopeNode(Object name) {
     if (name == null) {
@@ -264,6 +265,9 @@ public abstract class ScopeNode implements Scope {
 
   void close() {
     isOpen = false;
+    if(this.closeListener != null) {
+      closeListener.onClosed();
+    }
   }
 
   private void checkIsAnnotationScope(Class<? extends Annotation> scopeAnnotationClass) {
@@ -275,5 +279,10 @@ public abstract class ScopeNode implements Scope {
 
   private boolean isScopeAnnotationClass(Class<? extends Annotation> scopeAnnotationClass) {
     return scopeAnnotationClass.isAnnotationPresent(javax.inject.Scope.class);
+  }
+
+  @Override
+  public void setClosedListener(ScopeClosedListener closeListener) {
+    this.closeListener = closeListener;
   }
 }

--- a/toothpick/src/main/java/toothpick/Scope.java
+++ b/toothpick/src/main/java/toothpick/Scope.java
@@ -192,4 +192,6 @@ public interface Scope {
    * @param modules an array of modules that define test bindings.
    */
   void installTestModules(Module... modules);
+
+  void setClosedListener(ScopeClosedListener closeListener);
 }

--- a/toothpick/src/main/java/toothpick/ScopeClosedListener.java
+++ b/toothpick/src/main/java/toothpick/ScopeClosedListener.java
@@ -1,0 +1,5 @@
+package toothpick;
+
+public interface ScopeClosedListener {
+  void onClosed();
+}


### PR DESCRIPTION
Small experiment...

What is not so good is that we can easily create activity leaks with the closedListener:

```java
//method ref 
//= lambda 
//= anonymous inner class 
//= leak of this as it remains in the presenter scope.
 openScope(PRESENTER_SCOPE).setClosedListener(rxPresenter::stop); 
```

It does not actually :D 
```java
// $FF: synthetic class
final class RxMVPActivity$$Lambda$4 implements ScopeClosedListener {
    private final RxPresenter arg$1;

    private RxMVPActivity$$Lambda$4(RxPresenter var1) {
        this.arg$1 = var1;
    }

    private static ScopeClosedListener get$Lambda(RxPresenter var0) {
        return new RxMVPActivity$$Lambda$4(var0);
    }

    @Hidden
    public void onClosed() {
        this.arg$1.stop();
    }

    public static ScopeClosedListener lambdaFactory$(RxPresenter var0) {
        return new RxMVPActivity$$Lambda$4(var0);
    }
}
```

because of [retro lambda optimizing stateless lambdas to singletons](https://github.com/orfjackal/retrolambda#backported-language-features).

I checked and there is no leak. Moreover we don't need to call stop on the subject... it's just garbage collected. 

We should add this kind of stuff, maybe with a better API though ;)