### PR TITLE
Add Toothpick.hasScope method for check scope in scopes tree.

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -30,15 +30,14 @@ public final class Toothpick {
 
   /**
    * Find scope by this {@code name} in current scopes tree.
-   * @return true if scope is exist.
+   * @return true if scope exist.
    */
   public static boolean hasScope(Object name) {
     if (name == null) {
       throw new IllegalArgumentException("null scope names are not allowed.");
     }
 
-    Scope scope = MAP_KEY_TO_SCOPE.get(name);
-    return scope != null;
+    return MAP_KEY_TO_SCOPE.containsKey(name);
   }
 
   /**

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -29,8 +29,10 @@ public final class Toothpick {
   }
 
   /**
-   * Find scope by this {@code name} in current scopes tree.
-   * @return true if scope exist.
+   * Indicates whether a scope is open.
+   *
+   * @param name the name of the scope.
+   * @return true if the scope has been opened and not yet closed.
    */
   public static boolean isScopeOpen(Object name) {
     if (name == null) {

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -29,6 +29,19 @@ public final class Toothpick {
   }
 
   /**
+   * Find scope by this {@code name} in current scopes tree.
+   * @return true if scope is exist.
+   */
+  public static boolean hasScope(Object name) {
+    if (name == null) {
+      throw new IllegalArgumentException("null scope names are not allowed.");
+    }
+
+    Scope scope = MAP_KEY_TO_SCOPE.get(name);
+    return scope != null;
+  }
+
+  /**
    * Opens multiple scopes in a row.
    * Opened scopes will be children of each other in left to right order (e.g. {@code
    * openScopes(a,b)} opens scopes {@code a} and {@code b}

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -32,7 +32,7 @@ public final class Toothpick {
    * Find scope by this {@code name} in current scopes tree.
    * @return true if scope exist.
    */
-  public static boolean hasScope(Object name) {
+  public static boolean isScopeOpen(Object name) {
     if (name == null) {
       throw new IllegalArgumentException("null scope names are not allowed.");
     }

--- a/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
@@ -241,7 +241,7 @@ public class ToothpickTest extends ToothpickBaseTest {
     //GIVEN
 
     //WHEN
-    Boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
+    boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
 
     //THEN
     assertThat(isFooScopeOpen, is(false));
@@ -253,7 +253,7 @@ public class ToothpickTest extends ToothpickBaseTest {
     Toothpick.openScope("foo");
 
     //WHEN
-    Boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
+    boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
 
     //THEN
     assertThat(isFooScopeOpen, is(true));
@@ -266,7 +266,7 @@ public class ToothpickTest extends ToothpickBaseTest {
 
     //WHEN
     Toothpick.closeScope("foo");
-    Boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
+    boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
 
     //THEN
     assertThat(isFooScopeOpen, is(false));
@@ -279,7 +279,7 @@ public class ToothpickTest extends ToothpickBaseTest {
 
     //WHEN
     Toothpick.closeScope("foo");
-    Boolean isBarScopeOpen = Toothpick.isScopeOpen("bar");
+    boolean isBarScopeOpen = Toothpick.isScopeOpen("bar");
 
     //THEN
     assertThat(isBarScopeOpen, is(false));

--- a/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
@@ -236,6 +236,55 @@ public class ToothpickTest extends ToothpickBaseTest {
     verify(mockScope);
   }
 
+  @Test
+  public void isScopeOpen_shouldReturnFalse_WhenThisScopesWasNotCreated() throws Exception {
+    //GIVEN
+
+    //WHEN
+    Boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
+
+    //THEN
+    assertThat(isFooScopeOpen, is(false));
+  }
+
+  @Test
+  public void isScopeOpen_shouldReturnTrue_WhenThisScopesWasCreated() throws Exception {
+    //GIVEN
+    Toothpick.openScope("foo");
+
+    //WHEN
+    Boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
+
+    //THEN
+    assertThat(isFooScopeOpen, is(true));
+  }
+
+  @Test
+  public void isScopeOpen_shouldReturnFalse_WhenThisScopesWasClosed() throws Exception {
+    //GIVEN
+    Toothpick.openScope("foo");
+
+    //WHEN
+    Toothpick.closeScope("foo");
+    Boolean isFooScopeOpen = Toothpick.isScopeOpen("foo");
+
+    //THEN
+    assertThat(isFooScopeOpen, is(false));
+  }
+
+  @Test
+  public void isScopeOpen_shouldReturnFalse_WhenParentScopesWasClosed() throws Exception {
+    //GIVEN
+    Toothpick.openScopes("foo", "bar");
+
+    //WHEN
+    Toothpick.closeScope("foo");
+    Boolean isBarScopeOpen = Toothpick.isScopeOpen("bar");
+
+    //THEN
+    assertThat(isBarScopeOpen, is(false));
+  }
+
   @After
   public void tearDown() throws Exception {
     Toothpick.reset();


### PR DESCRIPTION
Example of usage:
We can use it method for first initialization UI scope after Activity restore on Android OS.

At the moment we should to do like this:
[BaseFragment.kt](https://gitlab.com/terrakok/gitlab-client/blob/develop/app/src/main/java/ru/terrakok/gitlabclient/ui/global/BaseFragment.kt#L46)
😭😭😭