### PR TITLE
Fixing issue 362 and improvement

### DIFF
--- a/ktp/src/main/kotlin/toothpick/InjectorReplacer.kt
+++ b/ktp/src/main/kotlin/toothpick/InjectorReplacer.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Stephane Nicolas
+ * Copyright 2019 Daniel Molinero Reguera
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package toothpick
 
 import toothpick.ktp.KTP

--- a/ktp/src/main/kotlin/toothpick/InjectorReplacer.kt
+++ b/ktp/src/main/kotlin/toothpick/InjectorReplacer.kt
@@ -9,12 +9,12 @@ object InjectorReplacer {
 
     fun replace() {
         Toothpick.injector = object : InjectorImpl() {
-            override fun <T : Any> inject(obj: T, scope: Scope) =
+            override fun <T : Any> inject(obj: T, scope: Scope) {
                 if (KTP.delegateNotifier.hasDelegates(obj)) {
                     KTP.delegateNotifier.notifyDelegates(obj, scope)
-                } else {
-                    super.inject(obj, scope)
                 }
+                super.inject(obj, scope)
+            }
         }
     }
 }

--- a/ktp/src/main/kotlin/toothpick/InjectorReplacer.kt
+++ b/ktp/src/main/kotlin/toothpick/InjectorReplacer.kt
@@ -1,0 +1,20 @@
+package toothpick
+
+import toothpick.ktp.KTP
+
+/**
+ * Replaces Toothpick injector to be able to notify delegates.
+ */
+object InjectorReplacer {
+
+    fun replace() {
+        Toothpick.injector = object : InjectorImpl() {
+            override fun <T : Any> inject(obj: T, scope: Scope) =
+                if (KTP.delegateNotifier.hasDelegates(obj)) {
+                    KTP.delegateNotifier.notifyDelegates(obj, scope)
+                } else {
+                    super.inject(obj, scope)
+                }
+        }
+    }
+}

--- a/ktp/src/main/kotlin/toothpick/TPInjectorReplace.kt
+++ b/ktp/src/main/kotlin/toothpick/TPInjectorReplace.kt
@@ -16,21 +16,9 @@
  */
 package toothpick
 
-import toothpick.ktp.KTP
-
 /**
- * Replaces Toothpick injector to be able to notify delegates.
+ * Bridge that makes it possible to modify the injector used by Toothpick.
  */
-object InjectorReplacer {
-
-    fun replace() {
-        Toothpick.injector = object : InjectorImpl() {
-            override fun <T : Any> inject(obj: T, scope: Scope) {
-                if (KTP.delegateNotifier.hasDelegates(obj)) {
-                    KTP.delegateNotifier.notifyDelegates(obj, scope)
-                }
-                super.inject(obj, scope)
-            }
-        }
-    }
+fun setToothpickInjector(injector: Injector) {
+    Toothpick.injector = injector
 }

--- a/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
+++ b/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
@@ -16,11 +16,12 @@
  */
 package toothpick.ktp
 
-import toothpick.InjectorReplacer
+import toothpick.InjectorImpl
 import toothpick.Scope
 import toothpick.Toothpick
 import toothpick.configuration.Configuration
 import toothpick.ktp.delegate.DelegateNotifier
+import toothpick.setToothpickInjector
 
 /**
  * Main Toothpick API entry point for Kotlin.
@@ -30,7 +31,14 @@ object KTP {
     val delegateNotifier = DelegateNotifier()
 
     init {
-        InjectorReplacer.replace()
+        setToothpickInjector(object : InjectorImpl() {
+            override fun <T : Any> inject(obj: T, scope: Scope) {
+                if (delegateNotifier.hasDelegates(obj)) {
+                    delegateNotifier.notifyDelegates(obj, scope)
+                }
+                super.inject(obj, scope)
+            }
+        })
     }
 
     fun openScope(name: Any): Scope = Toothpick.openScope(name)

--- a/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
+++ b/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
@@ -16,7 +16,7 @@
  */
 package toothpick.ktp
 
-import toothpick.InjectorImpl
+import toothpick.InjectorReplacer
 import toothpick.Scope
 import toothpick.Toothpick
 import toothpick.configuration.Configuration
@@ -25,32 +25,23 @@ import toothpick.ktp.delegate.DelegateNotifier
 /**
  * Main Toothpick API entry point for Kotlin.
  */
-class KTP : Toothpick() {
+object KTP {
 
-    companion object TP {
-        val delegateNotifier = DelegateNotifier()
+    val delegateNotifier = DelegateNotifier()
 
-        init {
-            injector = object : InjectorImpl() {
-                override fun <T : Any> inject(obj: T, scope: Scope) =
-                    if (delegateNotifier.hasDelegates(obj)) {
-                        delegateNotifier.notifyDelegates(obj, scope)
-                    } else {
-                        super.inject(obj, scope)
-                    }
-            }
-        }
-
-        fun openScope(name: Any): Scope = Toothpick.openScope(name)
-
-        fun openScope(name: Any, scopeConfig: Scope.ScopeConfig): Scope = Toothpick.openScope(name, scopeConfig)
-
-        fun openScopes(vararg names: Any): Scope = Toothpick.openScopes(*names)
-
-        fun closeScope(name: Any) = Toothpick.closeScope(name)
-
-        fun isScopeOpen(name: Any) = Toothpick.isScopeOpen(name)
-
-        fun setConfiguration(configuration: Configuration) = Toothpick.setConfiguration(configuration)
+    init {
+        InjectorReplacer.replace()
     }
+
+    fun openScope(name: Any): Scope = Toothpick.openScope(name)
+
+    fun openScope(name: Any, scopeConfig: Scope.ScopeConfig): Scope = Toothpick.openScope(name, scopeConfig)
+
+    fun openScopes(vararg names: Any): Scope = Toothpick.openScopes(*names)
+
+    fun closeScope(name: Any) = Toothpick.closeScope(name)
+
+    fun isScopeOpen(name: Any) = Toothpick.isScopeOpen(name)
+
+    fun setConfiguration(configuration: Configuration) = Toothpick.setConfiguration(configuration)
 }

--- a/ktp/src/test/kotlin/toothpick/ktp/binding/BindingExtensionTest.kt
+++ b/ktp/src/test/kotlin/toothpick/ktp/binding/BindingExtensionTest.kt
@@ -43,7 +43,7 @@ class BindingExtensionTest {
             bind<CharSequence>().toInstance("")
             bind<CharSequence>().toInstance { "" } // equivalent to previous one
             bind<CharSequence>().withName("").toInstance { "" }
-            bind<CharSequence>().withName(QualifierName::class).toClass<String>()
+            bind<CharSequence>().withName(QualifierName::class).toInstance { "" }
 
             // toProvider
             bind<CharSequence>().toProvider(StringProvider::class)

--- a/smoothie-lifecycle-viewmodel-ktp/src/test/kotlin/toothpick/smoothie/viewmodel/ViewModelUtilExtensionTest.kt
+++ b/smoothie-lifecycle-viewmodel-ktp/src/test/kotlin/toothpick/smoothie/viewmodel/ViewModelUtilExtensionTest.kt
@@ -31,7 +31,6 @@ import toothpick.Toothpick.isScopeOpen
 import toothpick.ktp.KTP
 import toothpick.ktp.binding.bind
 import toothpick.ktp.binding.module
-import toothpick.ktp.binding.toInstance
 
 @RunWith(RobolectricTestRunner::class)
 class ViewModelUtilExtensionTest {
@@ -44,7 +43,7 @@ class ViewModelUtilExtensionTest {
 
         // WHEN
         KTP.openScopes(application, activity)
-                .closeOnViewModelCleared(activity)
+            .closeOnViewModelCleared(activity)
         activityController.destroy()
 
         // THEN
@@ -60,7 +59,7 @@ class ViewModelUtilExtensionTest {
 
         // WHEN
         KTP.openScopes(application, activity)
-                .closeOnViewModelCleared(activity)
+            .closeOnViewModelCleared(activity)
         activityController.configurationChange(Configuration())
 
         // THEN
@@ -75,12 +74,12 @@ class ViewModelUtilExtensionTest {
         val application: Context = ApplicationProvider.getApplicationContext()
         // WHEN
         val scope = KTP.openScopes(application, ViewModelScope::class.java)
-                .installViewModelBinding<TestViewModel>(activity)
-                .closeOnViewModelCleared(activity)
-                .installModules(module {
-                    bind<String>().withName("name").toInstance { "dependency" }
-                })
-                .openSubScope(activity)
+            .installViewModelBinding<TestViewModel>(activity)
+            .closeOnViewModelCleared(activity)
+            .installModules(module {
+                bind<String>().withName("name").toInstance { "dependency" }
+            })
+            .openSubScope(activity)
 
         val viewModelBeforeRotation = scope.getInstance(TestViewModel::class.java)
         activityController.configurationChange(Configuration())

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -39,7 +39,7 @@ public class Toothpick {
   // its transformation
   private static final ConcurrentHashMap<Object, Scope> MAP_KEY_TO_SCOPE =
       new ConcurrentHashMap<>();
-  protected static Injector injector = new InjectorImpl();
+  static Injector injector = new InjectorImpl();
 
   protected Toothpick() {
     throw new RuntimeException("Constructor can't be invoked even via reflection.");

--- a/toothpick-sample/src/main/java/com/example/toothpick/BackpackApplication.kt
+++ b/toothpick-sample/src/main/java/com/example/toothpick/BackpackApplication.kt
@@ -6,7 +6,6 @@ import toothpick.Scope
 import toothpick.ktp.KTP
 import toothpick.ktp.binding.bind
 import toothpick.ktp.binding.module
-import toothpick.ktp.binding.toInstance
 
 class BackpackApplication : Application() {
 

--- a/toothpick-sample/src/main/java/com/example/toothpick/activity/AdvancedBackpackItemsActivity.kt
+++ b/toothpick-sample/src/main/java/com/example/toothpick/activity/AdvancedBackpackItemsActivity.kt
@@ -20,7 +20,6 @@ import toothpick.Scope
 import toothpick.ktp.KTP
 import toothpick.ktp.binding.bind
 import toothpick.ktp.binding.module
-import toothpick.ktp.binding.toClass
 import toothpick.ktp.delegate.inject
 import toothpick.ktp.delegate.lazy
 import toothpick.smoothie.lifecycle.closeOnDestroy

--- a/toothpick-sample/src/main/java/com/example/toothpick/activity/SimpleBackpackItemsActivity.kt
+++ b/toothpick-sample/src/main/java/com/example/toothpick/activity/SimpleBackpackItemsActivity.kt
@@ -18,7 +18,6 @@ import com.example.toothpick.model.Backpack
 import toothpick.ktp.KTP
 import toothpick.ktp.binding.bind
 import toothpick.ktp.binding.module
-import toothpick.ktp.binding.toClass
 import toothpick.ktp.delegate.inject
 import toothpick.ktp.delegate.lazy
 import toothpick.smoothie.lifecycle.closeOnDestroy


### PR DESCRIPTION
This PR contains the following changes:

* Solving [issue 362](https://github.com/stephanenicolas/toothpick/issues/362). In order to fix the problem, it moves KTP binding API to use classes instead of extension functions.
* Cleaning KTP class (no need to have companion object or extend Toothpick) and moving injector replacement logic to different class (single responsibility). Also it will not make it possible to write (the suggested way by the IDE...):
```kotlin
KTP.TP.openScope...
```
* Trigger member injection (annotated fields and annotated) even when delegates are used. This will allow to use method injection on roots using KTP.

These changes are improvements that do not change the public API.