### PR TITLE
Fixed Proguard rules for TP 3.x

### DIFF
--- a/smoothie/proguard-rules.txt
+++ b/smoothie/proguard-rules.txt
@@ -2,18 +2,26 @@
 -keepattributes *Annotation*
 # Do not obfuscate classes with Injected Constructors
 -keepclasseswithmembernames class * { @javax.inject.Inject <init>(...); }
+-keepnames @toothpick.InjectConstructor class *
 # Do not obfuscate classes with Injected Fields
 -keepclasseswithmembernames class * { @javax.inject.Inject <fields>; }
 # Do not obfuscate classes with Injected Methods
 -keepclasseswithmembernames class * { @javax.inject.Inject <methods>; }
--keep @android.support.annotation.Keep class *
--dontwarn javax.inject.**
--dontwarn javax.annotation.**
+# Do not obfuscate classes with Inject delegates
+-keepclasseswithmembernames class * { toothpick.ktp.delegate.* *; }
+-keep class javax.inject.**
+-keep class javax.annotation.**
 -keep class **__Factory { *; }
 -keep class **__MemberInjector { *; }
-
--adaptclassstrings
+-keepclassmembers class * {
+	@javax.inject.Inject <init>(...);
+	@javax.inject.Inject <init>();
+	@javax.inject.Inject <fields>;
+	public <init>(...);
+    toothpick.ktp.delegate.* *;
+}
 -keep class toothpick.** { *; }
 
 -keep @javax.inject.Singleton class *
-#You need to keep your custom scopes too
+# You need to keep your custom scopes too, e.g.
+# -keepnames @foo.bar.ActivityScope class *


### PR DESCRIPTION
This is to fix issues #370 & #330 .

`-adaptclassstrings` was removed as it was breaking Firebase.

`toothpick.ktp.delegate` rules were added to work in Kotlin with `by inject()`, `by lazy()` etc. 

I've also removed `-keep @android.support.annotation.Keep class *` as it probably shouldn't be there in the first place (that's my best guess though, I might be missing something).

Moreover, I've added a sample rule on how to custom scope rules in your own projects (the one at the bottom).

I've tested this set of rules in our production app with R8 (ProGuard rules fallback version) & Firebase Performance plugin.