### PR TITLE
add scope config methods for both kotlin and java. Add a test. Might …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ classes/
 .idea/
 build/
 .gradle
+android-studio.*

--- a/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
+++ b/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
@@ -45,6 +45,8 @@ object KTP {
 
     fun openRootScope(scopeConfig: (Scope) -> Unit): Scope = Toothpick.openRootScope(scopeConfig)
 
+    fun isRootScopeOpen(): Boolean = Toothpick.isRootScopeOpen()
+
     fun openScope(name: Any): Scope = Toothpick.openScope(name)
 
     fun openScope(name: Any, scopeConfig: (Scope) -> Unit): Scope = Toothpick.openScope(name, scopeConfig)

--- a/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
+++ b/ktp/src/main/kotlin/toothpick/ktp/KTP.kt
@@ -43,9 +43,11 @@ object KTP {
 
     fun openRootScope(): Scope = Toothpick.openRootScope()
 
+    fun openRootScope(scopeConfig: (Scope) -> Unit): Scope = Toothpick.openRootScope(scopeConfig)
+
     fun openScope(name: Any): Scope = Toothpick.openScope(name)
 
-    fun openScope(name: Any, scopeConfig: Scope.ScopeConfig): Scope = Toothpick.openScope(name, scopeConfig)
+    fun openScope(name: Any, scopeConfig: (Scope) -> Unit): Scope = Toothpick.openScope(name, scopeConfig)
 
     fun openScopes(vararg names: Any): Scope = Toothpick.openScopes(*names)
 

--- a/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
+++ b/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
@@ -40,12 +40,14 @@ class KTPTest {
     @Test
     fun `openRootScope should open default root scope`() {
         // GIVEN
+        KTP.isRootScopeOpen().shouldBeFalse()
 
         // WHEN
         val scope = KTP.openRootScope()
 
         // THEN
         scope.shouldNotBeNull()
+        KTP.isRootScopeOpen().shouldBeTrue()
     }
 
     @Test
@@ -57,6 +59,7 @@ class KTPTest {
 
         // THEN
         scope.shouldNotBeNull()
+        KTP.isRootScopeOpen().shouldBeTrue()
     }
 
     @Test

--- a/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
+++ b/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
@@ -53,13 +53,15 @@ class KTPTest {
     @Test
     fun `openRootScope should open default root scope with a scope config`() {
         // GIVEN
+        var configApplied = false
 
         // WHEN
-        val scope = KTP.openRootScope {}
+        val scope = KTP.openRootScope { configApplied = true}
 
         // THEN
         scope.shouldNotBeNull()
         KTP.isRootScopeOpen().shouldBeTrue()
+        configApplied.shouldBeTrue()
     }
 
     @Test
@@ -77,17 +79,19 @@ class KTPTest {
     }
 
     @Test
-    fun `openScope should open scope and provide configuration`() {
+    fun `openScope should open scope with a scope config`() {
         // GIVEN
         Toothpick.isScopeOpen("name").shouldBeFalse()
+        var configApplied = false
 
         // WHEN
-        val scope = KTP.openScope("name") { }
+        val scope = KTP.openScope("name") { configApplied = true }
 
         // THEN
         scope.name shouldEqual "name"
         Toothpick.isScopeOpen("name").shouldBeTrue()
         KTP.isScopeOpen("name").shouldBeTrue()
+        configApplied.shouldBeTrue()
     }
 
     @Test

--- a/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
+++ b/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
@@ -25,7 +25,6 @@ import org.amshove.kluent.shouldNotBe
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
-import toothpick.Scope
 import toothpick.Toothpick
 import toothpick.configuration.Configuration
 import toothpick.configuration.ConfigurationHolder
@@ -56,7 +55,7 @@ class KTPTest {
         var configApplied = false
 
         // WHEN
-        val scope = KTP.openRootScope { configApplied = true}
+        val scope = KTP.openRootScope { configApplied = true }
 
         // THEN
         scope.shouldNotBeNull()

--- a/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
+++ b/ktp/src/test/kotlin/toothpick/ktp/KTPTest.kt
@@ -49,6 +49,17 @@ class KTPTest {
     }
 
     @Test
+    fun `openRootScope should open default root scope with a scope config`() {
+        // GIVEN
+
+        // WHEN
+        val scope = KTP.openRootScope {}
+
+        // THEN
+        scope.shouldNotBeNull()
+    }
+
+    @Test
     fun `openScope should open scope`() {
         // GIVEN
         Toothpick.isScopeOpen("name").shouldBeFalse()
@@ -68,7 +79,7 @@ class KTPTest {
         Toothpick.isScopeOpen("name").shouldBeFalse()
 
         // WHEN
-        val scope = KTP.openScope("name", Scope.ScopeConfig { })
+        val scope = KTP.openScope("name") { }
 
         // THEN
         scope.name shouldEqual "name"

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -75,13 +75,13 @@ public class Toothpick {
    *
    * <ul>
    *   <li>if there's an existing scope tree the root scope of that tree;
-   *   <li>creates a default root scope if there's none; In this case, {@code scopeConfig}
-   *       is applied to the new scope.
+   *   <li>creates a default root scope if there's none; In this case, {@code scopeConfig} is
+   *       applied to the new scope.
    *   <li>throws an exception if there are multiple scope trees (e.g. a forest);
    * </ul>
    *
    * @param scopeConfig a lambda to configure the scope if it is created. The lambda is not applied
-   * if the scope existed already.
+   *     if the scope existed already.
    * @return the root scope.
    */
   public static Scope openRootScope(ScopeConfig scopeConfig) {

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -48,7 +48,7 @@ public class Toothpick {
   }
 
   /**
-   * Returns or opens a root scope as follows:<br>
+   * Creates or opens the previously created root scope as follows:<br>
    *
    * <ul>
    *   <li>if there's an existing scope tree the root scope of that tree;
@@ -67,6 +67,32 @@ public class Toothpick {
         return ROOT_SCOPES.values().iterator().next();
       }
       return openScope(Toothpick.class);
+    }
+  }
+
+  /**
+   * Creates or opens the previously created root scope as follows:<br>
+   *
+   * <ul>
+   *   <li>if there's an existing scope tree the root scope of that tree;
+   *   <li>creates a default root scope if there's none; In this case, {@code scopeConfig}
+   *       is applied to the new scope.
+   *   <li>throws an exception if there are multiple scope trees (e.g. a forest);
+   * </ul>
+   *
+   * @param scopeConfig a lambda to configure the scope if it is created. The lambda is not applied
+   * if the scope existed already.
+   * @return the root scope.
+   */
+  public static Scope openRootScope(ScopeConfig scopeConfig) {
+    synchronized (ROOT_SCOPES) {
+      if (ROOT_SCOPES.size() > 1) {
+        throw new RuntimeException(
+            "openRootScope() is not supported when multiple root scopes are enabled. Use 'Configuration.preventMultipleRootScopes()' to enable it.");
+      } else if (ROOT_SCOPES.size() == 1) {
+        return ROOT_SCOPES.values().iterator().next();
+      }
+      return openScope(Toothpick.class, scopeConfig);
     }
   }
 

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -85,15 +85,21 @@ public class Toothpick {
    * @return the root scope.
    */
   public static Scope openRootScope(ScopeConfig scopeConfig) {
-    synchronized (ROOT_SCOPES) {
-      if (ROOT_SCOPES.size() > 1) {
-        throw new RuntimeException(
-            "openRootScope() is not supported when multiple root scopes are enabled. Use 'Configuration.preventMultipleRootScopes()' to enable it.");
-      } else if (ROOT_SCOPES.size() == 1) {
-        return ROOT_SCOPES.values().iterator().next();
-      }
-      return openScope(Toothpick.class, scopeConfig);
+    if (isRootScopeOpen()) {
+      return openRootScope();
     }
+    Scope scope = openRootScope();
+    scopeConfig.configure(scope);
+    return scope;
+  }
+
+  /**
+   * Indicates whether the root scope is open.
+   *
+   * @return true if the root scope has been opened and not yet closed.
+   */
+  public static boolean isRootScopeOpen() {
+    return !ROOT_SCOPES.isEmpty();
   }
 
   /**

--- a/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -426,6 +428,20 @@ public class ToothpickTest {
     // THEN
     assertThat(rootScope, notNullValue());
     assertThat(rootScope.getName(), equalToObject(Toothpick.class));
+  }
+
+  @Test
+  public void openRootScope_shouldApplyConfig() {
+    // GIVEN
+    TestScopeConfig scopeConfig = new TestScopeConfig();
+
+    // WHEN
+    Scope rootScope = Toothpick.openRootScope(scopeConfig);
+
+    // THEN
+    assertThat(rootScope, notNullValue());
+    assertThat(rootScope.getName(), equalToObject(Toothpick.class));
+    assertThat(scopeConfig.wasApplied, is(true));
   }
 
   @Test(expected = RuntimeException.class)

--- a/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/ToothpickTest.java
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;


### PR DESCRIPTION
…need more

We were missing a few overloads for the kotlin and java APIs of KTP and TP. 

We are missing tests for TP openRootScope / isRootScopeOpen.
We are missing tests that check if the lambda / scope config is applied correctly.

