### PR TITLE
Prevent releasable factory cleanup

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/InternalProvider.java
+++ b/toothpick-runtime/src/main/java/toothpick/InternalProvider.java
@@ -132,8 +132,12 @@ public class InternalProvider<T> {
     if (factory != null) {
       if (isSingleton) {
         instance = factory.createInstance(scope);
-        // gc
-        factory = null;
+
+        if (!isReleasable) {
+          // gc
+          factory = null;
+        }
+
         return instance;
       }
 
@@ -155,8 +159,12 @@ public class InternalProvider<T> {
     if (providerFactory != null) {
       if (isSingleton) {
         providerInstance = providerFactory.createInstance(scope);
-        // gc
-        providerFactory = null;
+
+        if (!isReleasable) {
+          // gc
+          providerFactory = null;
+        }
+
         if (isProvidingSingleton) {
           instance = providerInstance.get();
           return instance;
@@ -166,8 +174,11 @@ public class InternalProvider<T> {
 
       if (isProvidingSingleton) {
         instance = providerFactory.createInstance(scope).get();
-        // gc
-        providerFactory = null;
+
+        if (!isProvidingReleasable) {
+          // gc
+          providerFactory = null;
+        }
         return instance;
       }
 

--- a/toothpick-runtime/src/test/java/toothpick/InternalProviderTest.java
+++ b/toothpick-runtime/src/test/java/toothpick/InternalProviderTest.java
@@ -16,12 +16,24 @@
  */
 package toothpick;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import javax.inject.Provider;
+import org.junit.Rule;
 import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import toothpick.locators.FactoryLocator;
 
+@PrepareForTest(FactoryLocator.class)
 public class InternalProviderTest {
+
+  public @Rule PowerMockRule rule = new PowerMockRule();
 
   @Test(expected = IllegalArgumentException.class)
   public void testCreateInternalProviderImpl_shouldFail_whenInstanceIsNull() {
@@ -71,6 +83,65 @@ public class InternalProviderTest {
 
     // THEN
     fail("Should throw an exception");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGet_releasableFactorySingleton_afterRelease() {
+    Factory<String> mockFactory = mock(Factory.class);
+    when(mockFactory.hasSingletonAnnotation()).thenReturn(true);
+    when(mockFactory.hasReleasableAnnotation()).thenReturn(true);
+    when(mockFactory.createInstance(any(Scope.class))).thenReturn("hello world");
+
+    Scope mockScope = mock(Scope.class);
+
+    InternalProvider<String> provider = new InternalProvider<>(mockFactory);
+
+    assertEquals("hello world", provider.get(mockScope));
+    provider.release();
+    assertEquals("hello world", provider.get(mockScope));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGet_releasableProviderFactorySingleton_afterRelease() {
+    Provider<String> mockProvider = mock(Provider.class);
+    when(mockProvider.get()).thenReturn("hello world");
+
+    Factory<Provider<String>> mockFactory = mock(Factory.class);
+    when(mockFactory.createInstance(any(Scope.class))).thenReturn(mockProvider);
+
+    PowerMockito.mockStatic(FactoryLocator.class);
+    PowerMockito.when(FactoryLocator.getFactory(any(Class.class))).thenReturn(mockFactory);
+
+    Scope mockScope = mock(Scope.class);
+
+    InternalProvider provider = new InternalProvider(Provider.class, true, true, false, false);
+
+    assertEquals("hello world", provider.get(mockScope));
+    provider.release();
+    assertEquals("hello world", provider.get(mockScope));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testGet_releasableProviderFactoryProvidingSingleton_afterRelease() {
+    Provider<String> mockProvider = mock(Provider.class);
+    when(mockProvider.get()).thenReturn("hello world");
+
+    Factory<Provider<String>> mockFactory = mock(Factory.class);
+    when(mockFactory.createInstance(any(Scope.class))).thenReturn(mockProvider);
+
+    PowerMockito.mockStatic(FactoryLocator.class);
+    PowerMockito.when(FactoryLocator.getFactory(any(Class.class))).thenReturn(mockFactory);
+
+    Scope mockScope = mock(Scope.class);
+
+    InternalProvider provider = new InternalProvider(Provider.class, false, false, true, true);
+
+    assertEquals("hello world", provider.get(mockScope));
+    provider.release();
+    assertEquals("hello world", provider.get(mockScope));
   }
 
   /* TODO we should have unit tests for this


### PR DESCRIPTION
Only garbage collect the factory or provider factory if the
InternalProvider is not releasable. Otherwise, after being released
the provider will not have a factory available to re-create the
instance.

Fixes #398