### PR TITLE
Improve KTP inherited java API with nullability information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ subprojects { project ->
 
   repositories {
     jcenter()
+    google()
   }
 
   apply plugin: 'jacoco'

--- a/deps.gradle
+++ b/deps.gradle
@@ -9,6 +9,8 @@ ext.deps = [// Common
             android_plugin      : 'com.android.tools.build:gradle:3.4.2',
             supportv4           : 'com.android.support:support-v4:28.0.0',
             androidxv7          : 'androidx.appcompat:appcompat:1.0.0',
+            androidxannotations : 'androidx.annotation:annotation:1.1.0',
+
             fragment            : 'androidx.fragment:fragment:1.1.0',
             design              : 'com.google.android.material:material:1.0.0',
             coordlayout         : 'androidx.coordinatorlayout:coordinatorlayout:1.0.0',

--- a/smoothie-androidx/build.gradle
+++ b/smoothie-androidx/build.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'com.android.library'
 
-repositories {
-  google()
-}
-
 android {
   compileSdkVersion 28
 

--- a/smoothie-androidx/src/main/java/toothpick/smoothie/module/SmoothieAndroidXActivityModule.java
+++ b/smoothie-androidx/src/main/java/toothpick/smoothie/module/SmoothieAndroidXActivityModule.java
@@ -18,6 +18,7 @@ package toothpick.smoothie.module;
 
 import android.app.Activity;
 import android.view.LayoutInflater;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -27,7 +28,7 @@ import toothpick.smoothie.provider.AndroidXLoaderManagerProvider;
 import toothpick.smoothie.provider.LayoutInflaterProvider;
 
 public class SmoothieAndroidXActivityModule extends Module {
-  public SmoothieAndroidXActivityModule(FragmentActivity activity) {
+  public SmoothieAndroidXActivityModule(@NonNull FragmentActivity activity) {
     bind(Activity.class).toInstance(activity);
     bind(FragmentManager.class).toProviderInstance(new AndroidXFragmentManagerProvider(activity));
     bind(LoaderManager.class).toProviderInstance(new AndroidXLoaderManagerProvider(activity));

--- a/smoothie-androidx/src/main/java/toothpick/smoothie/provider/AndroidXFragmentManagerProvider.java
+++ b/smoothie-androidx/src/main/java/toothpick/smoothie/provider/AndroidXFragmentManagerProvider.java
@@ -17,6 +17,7 @@
 package toothpick.smoothie.provider;
 
 import android.app.Activity;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import javax.inject.Provider;
@@ -24,10 +25,11 @@ import javax.inject.Provider;
 public class AndroidXFragmentManagerProvider implements Provider<FragmentManager> {
   Activity activity;
 
-  public AndroidXFragmentManagerProvider(Activity activity) {
+  public AndroidXFragmentManagerProvider(@NonNull Activity activity) {
     this.activity = activity;
   }
 
+  @NonNull
   @Override
   public FragmentManager get() {
     return ((FragmentActivity) activity).getSupportFragmentManager();

--- a/smoothie-androidx/src/main/java/toothpick/smoothie/provider/AndroidXLoaderManagerProvider.java
+++ b/smoothie-androidx/src/main/java/toothpick/smoothie/provider/AndroidXLoaderManagerProvider.java
@@ -16,6 +16,7 @@
  */
 package toothpick.smoothie.provider;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 import androidx.loader.app.LoaderManager;
 import javax.inject.Provider;
@@ -23,10 +24,11 @@ import javax.inject.Provider;
 public class AndroidXLoaderManagerProvider implements Provider<LoaderManager> {
   FragmentActivity activity;
 
-  public AndroidXLoaderManagerProvider(FragmentActivity activity) {
+  public AndroidXLoaderManagerProvider(@NonNull FragmentActivity activity) {
     this.activity = activity;
   }
 
+  @NonNull
   @Override
   public LoaderManager get() {
     return LoaderManager.getInstance(activity);

--- a/smoothie-lifecycle-viewmodel/src/main/java/toothpick/smoothie/viewmodel/ViewModelProvider.java
+++ b/smoothie-lifecycle-viewmodel/src/main/java/toothpick/smoothie/viewmodel/ViewModelProvider.java
@@ -126,6 +126,7 @@ public class ViewModelProvider<T extends ViewModel> implements Provider<T> {
     this.scope = scope;
   }
 
+  @NonNull
   @Override
   public T get() {
     if (scope != null) {

--- a/smoothie-lifecycle-viewmodel/src/main/java/toothpick/smoothie/viewmodel/ViewModelUtil.java
+++ b/smoothie-lifecycle-viewmodel/src/main/java/toothpick/smoothie/viewmodel/ViewModelUtil.java
@@ -113,7 +113,7 @@ public class ViewModelUtil {
   private static class TPViewModelFactory implements Factory {
     private Scope scope;
 
-    private TPViewModelFactory(Scope scope) {
+    private TPViewModelFactory(@NonNull Scope scope) {
       this.scope = scope;
     }
 
@@ -132,8 +132,7 @@ public class ViewModelUtil {
   private static class TPViewModel extends ViewModel {
     private Scope scope;
 
-    private TPViewModel(Scope scope) {
-
+    private TPViewModel(@NonNull Scope scope) {
       this.scope = scope;
     }
 

--- a/smoothie-support/build.gradle
+++ b/smoothie-support/build.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'com.android.library'
 
-repositories {
-  google()
-}
-
 android {
   compileSdkVersion 28
 

--- a/smoothie/build.gradle
+++ b/smoothie/build.gradle
@@ -1,10 +1,5 @@
 apply plugin: 'com.android.library'
 
-repositories {
-  google()
-}
-
-
 android {
   compileSdkVersion 28
 
@@ -30,6 +25,7 @@ android {
 dependencies {
   api project(':toothpick-runtime')
   compileOnly deps.inject
+  compileOnly deps.androidxannotations
 
   testImplementation project(':toothpick-testing')
   testImplementation deps.junit4

--- a/smoothie/src/main/java/toothpick/smoothie/module/SmoothieActivityModule.java
+++ b/smoothie/src/main/java/toothpick/smoothie/module/SmoothieActivityModule.java
@@ -18,6 +18,7 @@ package toothpick.smoothie.module;
 
 import android.app.Activity;
 import android.view.LayoutInflater;
+import androidx.annotation.NonNull;
 import toothpick.config.Module;
 import toothpick.smoothie.provider.FragmentManagerProvider;
 import toothpick.smoothie.provider.LayoutInflaterProvider;
@@ -25,7 +26,7 @@ import toothpick.smoothie.provider.LoaderManagerProvider;
 
 @SuppressWarnings("deprecation")
 public class SmoothieActivityModule extends Module {
-  public SmoothieActivityModule(Activity activity) {
+  public SmoothieActivityModule(@NonNull Activity activity) {
     bind(Activity.class).toInstance(activity);
     bind(android.app.FragmentManager.class)
         .toProviderInstance(new FragmentManagerProvider(activity));

--- a/smoothie/src/main/java/toothpick/smoothie/module/SmoothieApplicationModule.java
+++ b/smoothie/src/main/java/toothpick/smoothie/module/SmoothieApplicationModule.java
@@ -60,6 +60,8 @@ import android.os.Vibrator;
 import android.telephony.TelephonyManager;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import toothpick.config.Module;
 import toothpick.smoothie.provider.AccountManagerProvider;
 import toothpick.smoothie.provider.AssetManagerProvider;
@@ -71,11 +73,12 @@ import toothpick.smoothie.provider.SharedPreferencesProvider;
 import toothpick.smoothie.provider.SystemServiceProvider;
 
 public class SmoothieApplicationModule extends Module {
-  public SmoothieApplicationModule(Application application) {
+  public SmoothieApplicationModule(@NonNull Application application) {
     this(application, null);
   }
 
-  public SmoothieApplicationModule(Application application, String preferencesName) {
+  public SmoothieApplicationModule(
+      @NonNull Application application, @Nullable String preferencesName) {
     bind(Application.class).toInstance(application);
     bind(AccountManager.class).toProviderInstance(new AccountManagerProvider(application));
     bind(AssetManager.class).toProviderInstance(new AssetManagerProvider(application));
@@ -89,7 +92,7 @@ public class SmoothieApplicationModule extends Module {
     bindPackageInfo(application);
   }
 
-  private void bindPackageInfo(Application application) {
+  private void bindPackageInfo(@NonNull Application application) {
     final PackageInfo packageInfo;
     try {
       packageInfo = application.getPackageManager().getPackageInfo(application.getPackageName(), 0);
@@ -99,7 +102,7 @@ public class SmoothieApplicationModule extends Module {
     }
   }
 
-  private void bindSystemServices(Application application) {
+  private void bindSystemServices(@NonNull Application application) {
     bindSystemService(application, LocationManager.class, LOCATION_SERVICE);
     bindSystemService(application, WindowManager.class, WINDOW_SERVICE);
     bindSystemService(application, ActivityManager.class, ACTIVITY_SERVICE);

--- a/smoothie/src/main/java/toothpick/smoothie/provider/AccountManagerProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/AccountManagerProvider.java
@@ -18,15 +18,17 @@ package toothpick.smoothie.provider;
 
 import android.accounts.AccountManager;
 import android.app.Application;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class AccountManagerProvider implements Provider<AccountManager> {
   Application application;
 
-  public AccountManagerProvider(Application application) {
+  public AccountManagerProvider(@NonNull Application application) {
     this.application = application;
   }
 
+  @NonNull
   @Override
   public AccountManager get() {
     return AccountManager.get(application);

--- a/smoothie/src/main/java/toothpick/smoothie/provider/AssetManagerProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/AssetManagerProvider.java
@@ -18,15 +18,17 @@ package toothpick.smoothie.provider;
 
 import android.app.Application;
 import android.content.res.AssetManager;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class AssetManagerProvider implements Provider<AssetManager> {
   Application application;
 
-  public AssetManagerProvider(Application application) {
+  public AssetManagerProvider(@NonNull Application application) {
     this.application = application;
   }
 
+  @NonNull
   @Override
   public AssetManager get() {
     return application.getAssets();

--- a/smoothie/src/main/java/toothpick/smoothie/provider/ContentResolverProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/ContentResolverProvider.java
@@ -18,15 +18,17 @@ package toothpick.smoothie.provider;
 
 import android.app.Application;
 import android.content.ContentResolver;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class ContentResolverProvider implements Provider<ContentResolver> {
   Application application;
 
-  public ContentResolverProvider(Application application) {
+  public ContentResolverProvider(@NonNull Application application) {
     this.application = application;
   }
 
+  @NonNull
   @Override
   public ContentResolver get() {
     return application.getContentResolver();

--- a/smoothie/src/main/java/toothpick/smoothie/provider/FragmentManagerProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/FragmentManagerProvider.java
@@ -17,16 +17,18 @@
 package toothpick.smoothie.provider;
 
 import android.app.Activity;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 @SuppressWarnings("deprecation")
 public class FragmentManagerProvider implements Provider<android.app.FragmentManager> {
   Activity activity;
 
-  public FragmentManagerProvider(Activity activity) {
+  public FragmentManagerProvider(@NonNull Activity activity) {
     this.activity = activity;
   }
 
+  @NonNull
   @Override
   public android.app.FragmentManager get() {
     return activity.getFragmentManager();

--- a/smoothie/src/main/java/toothpick/smoothie/provider/HandlerProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/HandlerProvider.java
@@ -18,11 +18,13 @@ package toothpick.smoothie.provider;
 
 import android.os.Handler;
 import android.os.Looper;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class HandlerProvider implements Provider<Handler> {
   public HandlerProvider() {}
 
+  @NonNull
   @Override
   public Handler get() {
     return new Handler(Looper.getMainLooper());

--- a/smoothie/src/main/java/toothpick/smoothie/provider/LayoutInflaterProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/LayoutInflaterProvider.java
@@ -18,15 +18,17 @@ package toothpick.smoothie.provider;
 
 import android.app.Activity;
 import android.view.LayoutInflater;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class LayoutInflaterProvider implements Provider<LayoutInflater> {
   Activity activity;
 
-  public LayoutInflaterProvider(Activity activity) {
+  public LayoutInflaterProvider(@NonNull Activity activity) {
     this.activity = activity;
   }
 
+  @NonNull
   @Override
   public LayoutInflater get() {
     return LayoutInflater.from(activity);

--- a/smoothie/src/main/java/toothpick/smoothie/provider/LoaderManagerProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/LoaderManagerProvider.java
@@ -17,16 +17,18 @@
 package toothpick.smoothie.provider;
 
 import android.app.Activity;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 @SuppressWarnings("deprecation")
 public class LoaderManagerProvider implements Provider<android.app.LoaderManager> {
   Activity activity;
 
-  public LoaderManagerProvider(Activity activity) {
+  public LoaderManagerProvider(@NonNull Activity activity) {
     this.activity = activity;
   }
 
+  @NonNull
   @Override
   public android.app.LoaderManager get() {
     return activity.getLoaderManager();

--- a/smoothie/src/main/java/toothpick/smoothie/provider/PackageManagerProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/PackageManagerProvider.java
@@ -18,15 +18,17 @@ package toothpick.smoothie.provider;
 
 import android.app.Application;
 import android.content.pm.PackageManager;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class PackageManagerProvider implements Provider<PackageManager> {
   Application application;
 
-  public PackageManagerProvider(Application application) {
+  public PackageManagerProvider(@NonNull Application application) {
     this.application = application;
   }
 
+  @NonNull
   @Override
   public PackageManager get() {
     return application.getPackageManager();

--- a/smoothie/src/main/java/toothpick/smoothie/provider/ResourcesProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/ResourcesProvider.java
@@ -18,15 +18,17 @@ package toothpick.smoothie.provider;
 
 import android.app.Application;
 import android.content.res.Resources;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class ResourcesProvider implements Provider<Resources> {
   Application application;
 
-  public ResourcesProvider(Application application) {
+  public ResourcesProvider(@NonNull Application application) {
     this.application = application;
   }
 
+  @NonNull
   @Override
   public Resources get() {
     return application.getResources();

--- a/smoothie/src/main/java/toothpick/smoothie/provider/SharedPreferencesProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/SharedPreferencesProvider.java
@@ -20,21 +20,25 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import javax.inject.Provider;
 
 public class SharedPreferencesProvider implements Provider<SharedPreferences> {
   Application application;
   String preferencesName;
 
-  public SharedPreferencesProvider(Application application) {
+  public SharedPreferencesProvider(@NonNull Application application) {
     this(application, null);
   }
 
-  public SharedPreferencesProvider(Application application, String preferencesName) {
+  public SharedPreferencesProvider(
+      @NonNull Application application, @Nullable String preferencesName) {
     this.application = application;
     this.preferencesName = preferencesName;
   }
 
+  @NonNull
   @Override
   public SharedPreferences get() {
     if (preferencesName != null) {

--- a/smoothie/src/main/java/toothpick/smoothie/provider/SystemServiceProvider.java
+++ b/smoothie/src/main/java/toothpick/smoothie/provider/SystemServiceProvider.java
@@ -17,18 +17,20 @@
 package toothpick.smoothie.provider;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import javax.inject.Provider;
 
 public class SystemServiceProvider<T> implements Provider<T> {
   private Context context;
   private String serviceName;
 
-  public SystemServiceProvider(Context context, String serviceName) {
+  public SystemServiceProvider(@NonNull Context context, @NonNull String serviceName) {
     this.context = context;
     this.serviceName = serviceName;
   }
 
   @SuppressWarnings("unchecked")
+  @NonNull
   @Override
   public T get() {
     return (T) context.getSystemService(serviceName);

--- a/toothpick-runtime/build.gradle
+++ b/toothpick-runtime/build.gradle
@@ -9,6 +9,7 @@ targetCompatibility = 1.7
 dependencies {
   api project(':toothpick')
   api deps.inject
+  api deps.androidxannotations
 
   testImplementation deps.junit4
   testImplementation deps.hamcrest

--- a/toothpick-runtime/src/main/java/toothpick/InjectorImpl.java
+++ b/toothpick-runtime/src/main/java/toothpick/InjectorImpl.java
@@ -16,6 +16,7 @@
  */
 package toothpick;
 
+import androidx.annotation.NonNull;
 import toothpick.locators.MemberInjectorLocator;
 
 /** Default implementation of an injector. */
@@ -28,7 +29,7 @@ public class InjectorImpl implements Injector {
    */
   @Override
   @SuppressWarnings("unchecked")
-  public <T> void inject(T obj, Scope scope) {
+  public <T> void inject(@NonNull T obj, @NonNull Scope scope) {
     Class<? super T> currentClass = (Class<T>) obj.getClass();
     do {
       MemberInjector<? super T> memberInjector =

--- a/toothpick-runtime/src/main/java/toothpick/Toothpick.java
+++ b/toothpick-runtime/src/main/java/toothpick/Toothpick.java
@@ -16,6 +16,7 @@
  */
 package toothpick;
 
+import androidx.annotation.NonNull;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import toothpick.Scope.ScopeConfig;
@@ -58,7 +59,7 @@ public class Toothpick {
    *
    * @return the root scope.
    */
-  public static Scope openRootScope() {
+  public static @NonNull Scope openRootScope() {
     synchronized (ROOT_SCOPES) {
       if (ROOT_SCOPES.size() > 1) {
         throw new RuntimeException(
@@ -84,7 +85,7 @@ public class Toothpick {
    *     if the scope existed already.
    * @return the root scope.
    */
-  public static Scope openRootScope(ScopeConfig scopeConfig) {
+  public static @NonNull Scope openRootScope(@NonNull ScopeConfig scopeConfig) {
     if (isRootScopeOpen()) {
       return openRootScope();
     }
@@ -108,7 +109,7 @@ public class Toothpick {
    * @param name the name of the scope.
    * @return true if the scope has been opened and not yet closed.
    */
-  public static boolean isScopeOpen(Object name) {
+  public static boolean isScopeOpen(@NonNull Object name) {
     if (name == null) {
       throw new IllegalArgumentException("null scope names are not allowed.");
     }
@@ -124,7 +125,7 @@ public class Toothpick {
    * @param names of the scopes to open hierarchically.
    * @return the last opened scope, leaf node of the created subtree of scopes.
    */
-  public static Scope openScopes(Object... names) {
+  public static Scope openScopes(@NonNull Object... names) {
 
     if (names == null) {
       throw new IllegalArgumentException("null scope names are not allowed.");
@@ -154,7 +155,7 @@ public class Toothpick {
    * @see #openScope(Object, ScopeConfig)
    * @see #closeScope(Object)
    */
-  public static Scope openScope(Object name) {
+  public static @NonNull Scope openScope(@NonNull Object name) {
     return openScope(name, true);
   }
 
@@ -170,7 +171,7 @@ public class Toothpick {
    * @see #openScope(Object)
    * @see #closeScope(Object)
    */
-  public static Scope openScope(Object name, ScopeConfig scopeConfig) {
+  public static @NonNull Scope openScope(@NonNull Object name, ScopeConfig scopeConfig) {
     if (isScopeOpen(name)) {
       return openScope(name);
     }
@@ -186,7 +187,7 @@ public class Toothpick {
    * @param name the name of the scope to open.
    * @param isRootScope whether or not this is a root scope
    */
-  private static Scope openScope(Object name, boolean isRootScope) {
+  private static @NonNull Scope openScope(@NonNull Object name, boolean isRootScope) {
     synchronized (ROOT_SCOPES) {
       if (name == null) {
         throw new IllegalArgumentException("null scope names are not allowed.");
@@ -215,7 +216,7 @@ public class Toothpick {
    *
    * @param name the name of the scope to close.
    */
-  public static void closeScope(Object name) {
+  public static void closeScope(@NonNull Object name) {
     synchronized (ROOT_SCOPES) {
       // we remove the scope first, so that other threads don't see it, and see the next snapshot of
       // the tree
@@ -248,7 +249,7 @@ public class Toothpick {
    *
    * @param scope the scope we want to reset.
    */
-  public static void reset(Scope scope) {
+  public static void reset(@NonNull Scope scope) {
     ScopeNode scopeNode = (ScopeNode) scope;
     scopeNode.reset();
   }
@@ -259,7 +260,7 @@ public class Toothpick {
    *
    * @param scope the scope we want to reset.
    */
-  public static void release(Scope scope) {
+  public static void release(@NonNull Scope scope) {
     ScopeNode scopeNode = (ScopeNode) scope;
     scopeNode.release();
   }
@@ -271,7 +272,7 @@ public class Toothpick {
    * @param obj the object to be injected.
    * @param scope the scope in which all dependencies are obtained.
    */
-  public static void inject(Object obj, Scope scope) {
+  public static void inject(@NonNull Object obj, @NonNull Scope scope) {
     injector.inject(obj, scope);
   }
 
@@ -282,7 +283,7 @@ public class Toothpick {
    *     We don't do anything else to the children nodes are they will be garbage collected soon. We
    *     just cut a whole sub-graph in the references graph of the JVM normally.
    */
-  private static void removeScopeAndChildrenFromMap(ScopeNode scope) {
+  private static void removeScopeAndChildrenFromMap(@NonNull ScopeNode scope) {
     MAP_KEY_TO_SCOPE.remove(scope.getName());
     scope.close();
     for (ScopeNode childScope : scope.childrenScopes.values()) {
@@ -295,7 +296,7 @@ public class Toothpick {
    *
    * @param configuration the configuration to use
    */
-  public static void setConfiguration(Configuration configuration) {
+  public static void setConfiguration(@NonNull Configuration configuration) {
     ConfigurationHolder.configuration = configuration;
   }
 

--- a/toothpick-runtime/src/main/java/toothpick/configuration/Configuration.java
+++ b/toothpick-runtime/src/main/java/toothpick/configuration/Configuration.java
@@ -16,6 +16,7 @@
  */
 package toothpick.configuration;
 
+import androidx.annotation.NonNull;
 import toothpick.Scope;
 import toothpick.config.Binding;
 
@@ -44,6 +45,7 @@ public class Configuration
    *
    * @return a development configuration.
    */
+  @NonNull
   public static Configuration forDevelopment() {
     final Configuration configuration = new Configuration();
     configuration.runtimeCheckConfiguration = new RuntimeCheckOnConfiguration();
@@ -56,6 +58,7 @@ public class Configuration
    *
    * @return a production configuration.
    */
+  @NonNull
   public static Configuration forProduction() {
     return new Configuration();
   }
@@ -65,6 +68,7 @@ public class Configuration
    *
    * @return a configuration that allows multiple root scopes.
    */
+  @NonNull
   public Configuration allowMultipleRootScopes() {
     this.multipleRootScopeCheckConfiguration = new MultipleRootScopeCheckOffConfiguration();
     return this;
@@ -77,28 +81,29 @@ public class Configuration
    *
    * @return a configuration that allows a single root scope.
    */
+  @NonNull
   public Configuration preventMultipleRootScopes() {
     this.multipleRootScopeCheckConfiguration = new MultipleRootScopeCheckOnConfiguration();
     return this;
   }
 
   @Override
-  public void checkIllegalBinding(Binding binding, Scope scope) {
+  public void checkIllegalBinding(@NonNull Binding binding, @NonNull Scope scope) {
     runtimeCheckConfiguration.checkIllegalBinding(binding, scope);
   }
 
   @Override
-  public void checkCyclesStart(Class clazz, String name) {
+  public void checkCyclesStart(@NonNull Class clazz, @NonNull String name) {
     runtimeCheckConfiguration.checkCyclesStart(clazz, name);
   }
 
   @Override
-  public void checkCyclesEnd(Class clazz, String name) {
+  public void checkCyclesEnd(@NonNull Class clazz, @NonNull String name) {
     runtimeCheckConfiguration.checkCyclesEnd(clazz, name);
   }
 
   @Override
-  public void checkMultipleRootScopes(Scope scope) {
+  public void checkMultipleRootScopes(@NonNull Scope scope) {
     multipleRootScopeCheckConfiguration.checkMultipleRootScopes(scope);
   }
 

--- a/toothpick-runtime/src/main/java/toothpick/configuration/RuntimeCheckConfiguration.java
+++ b/toothpick-runtime/src/main/java/toothpick/configuration/RuntimeCheckConfiguration.java
@@ -16,6 +16,7 @@
  */
 package toothpick.configuration;
 
+import androidx.annotation.NonNull;
 import toothpick.Scope;
 import toothpick.config.Binding;
 
@@ -27,7 +28,7 @@ interface RuntimeCheckConfiguration {
    * @param binding the binding being installed.
    * @param scope the scope where the binding is installed.
    */
-  void checkIllegalBinding(Binding binding, Scope scope);
+  void checkIllegalBinding(@NonNull Binding binding, @NonNull Scope scope);
 
   /**
    * Called when the class {@code class} starts being injected using the qualifier {@code name}.
@@ -37,7 +38,7 @@ interface RuntimeCheckConfiguration {
    * @param clazz the class to be injected.
    * @param name the name of the required injection.
    */
-  void checkCyclesStart(Class clazz, String name);
+  void checkCyclesStart(@NonNull Class clazz, @NonNull String name);
 
   /**
    * Called when the class {@code class} ends being injected using the qualifier {@code name}. Will
@@ -47,5 +48,5 @@ interface RuntimeCheckConfiguration {
    * @param clazz the class to be injected.
    * @param name the name of the required injection.
    */
-  void checkCyclesEnd(Class clazz, String name);
+  void checkCyclesEnd(@NonNull Class clazz, @NonNull String name);
 }

--- a/toothpick/build.gradle
+++ b/toothpick/build.gradle
@@ -5,6 +5,7 @@ targetCompatibility = 1.7
 
 dependencies {
   implementation deps.inject
+  implementation deps.androidxannotations
 
   testImplementation deps.junit4
 }

--- a/toothpick/src/main/java/toothpick/Injector.java
+++ b/toothpick/src/main/java/toothpick/Injector.java
@@ -16,6 +16,8 @@
  */
 package toothpick;
 
+import androidx.annotation.NonNull;
+
 /** Allows to inject members of a given instance. An injector works with a scope. */
 public interface Injector {
   /**
@@ -36,5 +38,5 @@ public interface Injector {
    * @param scope the scope in which all dependencies are obtained.
    * @param <T> the type of {@code clazz}.
    */
-  <T> void inject(T obj, Scope scope);
+  <T> void inject(@NonNull T obj, @NonNull Scope scope);
 }

--- a/toothpick/src/main/java/toothpick/MemberInjector.java
+++ b/toothpick/src/main/java/toothpick/MemberInjector.java
@@ -16,6 +16,8 @@
  */
 package toothpick;
 
+import androidx.annotation.NonNull;
+
 /**
  * Inject member of an instance of a class. All injected members are gonna be obtained in the scope
  * of the current scope. MemberInjector are discovered via the {@code MemberInjectorLocator}.
@@ -32,5 +34,5 @@ public interface MemberInjector<T> {
    * @param t the object in which to inject all dependencies.
    * @param scope the scope in which all dependencies of {@code t} will be looked for.
    */
-  void inject(T t, Scope scope);
+  void inject(@NonNull T t, @NonNull Scope scope);
 }

--- a/toothpick/src/main/java/toothpick/Scope.java
+++ b/toothpick/src/main/java/toothpick/Scope.java
@@ -16,6 +16,8 @@
  */
 package toothpick;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -68,9 +70,11 @@ public interface Scope {
    * @return the name of the scope. It is only used to access a node via the ToothPick class. The
    *     name can't be null.
    */
+  @NonNull
   Object getName();
 
   /** @return the parentScope of this scope. Can be null for a root scope. */
+  @Nullable
   Scope getParentScope();
 
   /**
@@ -84,12 +88,14 @@ public interface Scope {
    *     Singleton}, the root scope is always returned. Thus the {@link Singleton} scope annotation
    *     class doesn't need to be explicitely supported, it's built-in.
    */
-  <A extends Annotation> Scope getParentScope(Class<A> scopeAnnotationClass);
+  @NonNull
+  <A extends Annotation> Scope getParentScope(@NonNull Class<A> scopeAnnotationClass);
 
   /**
    * @return the root scope of this scope. The root scope is the scope itself if the scope has no
    *     parent. Otherwise, if it has parents, it is the highest parent in the hierarchy of parents.
    */
+  @NonNull
   Scope getRootScope();
 
   /**
@@ -102,7 +108,8 @@ public interface Scope {
    *     all root scopes (scopes with no parents).
    * @see #getParentScope(Class)
    */
-  Scope supportScopeAnnotation(Class<? extends Annotation> scopeAnnotationClass);
+  @NonNull
+  Scope supportScopeAnnotation(@NonNull Class<? extends Annotation> scopeAnnotationClass);
 
   boolean isScopeAnnotationSupported(Class<? extends Annotation> scopeAnnotationClass);
 
@@ -112,7 +119,8 @@ public interface Scope {
    * @see #getInstance(Class, String)
    * @see toothpick.config.Module
    */
-  <T> T getInstance(Class<T> clazz);
+  @NonNull
+  <T> T getInstance(@NonNull Class<T> clazz);
 
   /**
    * Returns the instance of {@code clazz} named {@code name} if one is scoped in the current scope,
@@ -127,7 +135,8 @@ public interface Scope {
    * @return a scoped instance or a new one produced by the factory associated to {@code clazz}.
    * @see toothpick.config.Binding
    */
-  <T> T getInstance(Class<T> clazz, String name);
+  @NonNull
+  <T> T getInstance(@NonNull Class<T> clazz, @Nullable String name);
 
   /**
    * Requests a provider via an unnamed binding.
@@ -135,7 +144,8 @@ public interface Scope {
    * @see #getProvider(Class, String)
    * @see toothpick.config.Module
    */
-  <T> Provider<T> getProvider(Class<T> clazz);
+  @NonNull
+  <T> Provider<T> getProvider(@NonNull Class<T> clazz);
 
   /**
    * Returns a named {@code Provider} named {@code name} of {@code clazz} if one is scoped in the
@@ -151,7 +161,8 @@ public interface Scope {
    *     providers are thread safe.
    * @see toothpick.config.Module
    */
-  <T> Provider<T> getProvider(Class<T> clazz, String name);
+  @NonNull
+  <T> Provider<T> getProvider(@NonNull Class<T> clazz, @Nullable String name);
 
   /**
    * Requests a Lazy via an unnamed binding.
@@ -159,7 +170,8 @@ public interface Scope {
    * @see #getLazy(Class, String)
    * @see toothpick.config.Module
    */
-  <T> Lazy<T> getLazy(Class<T> clazz);
+  @NonNull
+  <T> Lazy<T> getLazy(@NonNull Class<T> clazz);
 
   /**
    * Returns a {@code Lazy} named {@code name} of {@code clazz} if one provider is scoped in the
@@ -177,7 +189,8 @@ public interface Scope {
    *     lazies are thread safe.
    * @see toothpick.config.Module
    */
-  <T> Lazy<T> getLazy(Class<T> clazz, String name);
+  @NonNull
+  <T> Lazy<T> getLazy(@NonNull Class<T> clazz, @Nullable String name);
 
   /**
    * Allows to install modules.
@@ -185,7 +198,8 @@ public interface Scope {
    * @param modules an array of modules that define bindings.
    * @see #installTestModules
    */
-  Scope installModules(Module... modules);
+  @NonNull
+  Scope installModules(@NonNull Module... modules);
 
   /**
    * <em>DO NOT USE IT IN PRODUCTION.</em><br>
@@ -197,7 +211,8 @@ public interface Scope {
    *
    * @param modules an array of modules that define test bindings.
    */
-  Scope installTestModules(Module... modules);
+  @NonNull
+  Scope installTestModules(@NonNull Module... modules);
 
   /**
    * Injects all dependencies (transitively) in {@code obj}, dependencies will be obtained in the
@@ -205,7 +220,7 @@ public interface Scope {
    *
    * @param obj the object to be injected.
    */
-  void inject(Object obj);
+  void inject(@NonNull Object obj);
 
   /**
    * Release all releasable singletons. Factories and internal providers won't be released.
@@ -220,7 +235,8 @@ public interface Scope {
    * @param subScopeName the <em>name of the scope</em>.
    * @see #openSubScope(Object)
    */
-  Scope openSubScope(Object subScopeName);
+  @NonNull
+  Scope openSubScope(@NonNull Object subScopeName);
 
   /**
    * Opens a sub scope of this scope. If a child scope by this {@code name} already exists, it is
@@ -232,10 +248,11 @@ public interface Scope {
    *     if the scope existed already.
    * @see #openSubScope(Object)
    */
-  Scope openSubScope(Object subScopeName, ScopeConfig scopeConfig);
+  @NonNull
+  Scope openSubScope(@NonNull Object subScopeName, @NonNull ScopeConfig scopeConfig);
 
   @FunctionalInterface
   interface ScopeConfig {
-    void configure(Scope scope);
+    void configure(@NonNull Scope scope);
   }
 }

--- a/toothpick/src/main/java/toothpick/config/Binding.java
+++ b/toothpick/src/main/java/toothpick/config/Binding.java
@@ -16,6 +16,7 @@
  */
 package toothpick.config;
 
+import androidx.annotation.NonNull;
 import java.lang.annotation.Annotation;
 import javax.inject.Provider;
 import javax.inject.Qualifier;
@@ -33,40 +34,48 @@ public class Binding<T> {
   private boolean isProvidingSingleton;
   private boolean isProvidingReleasable;
 
-  public Binding(Class<T> key) {
+  public Binding(@NonNull Class<T> key) {
     this.key = key;
     mode = Mode.SIMPLE;
   }
 
+  @NonNull
   public CanBeReleasable singleton() {
     isCreatingSingleton = true;
     return new CanBeReleasable();
   }
 
+  @NonNull
   public Mode getMode() {
     return mode;
   }
 
+  @NonNull
   public Class<T> getKey() {
     return key;
   }
 
+  @NonNull
   public Class<? extends T> getImplementationClass() {
     return implementationClass;
   }
 
+  @NonNull
   public T getInstance() {
     return instance;
   }
 
+  @NonNull
   public Provider<? extends T> getProviderInstance() {
     return providerInstance;
   }
 
+  @NonNull
   public Class<? extends Provider<? extends T>> getProviderClass() {
     return providerClass;
   }
 
+  @NonNull
   public String getName() {
     return name;
   }
@@ -100,13 +109,15 @@ public class Binding<T> {
   // *************************
 
   public class CanBeNamed extends CanBeBound {
-    public CanBeBound withName(String name) {
+    @NonNull
+    public CanBeBound withName(@NonNull String name) {
       Binding.this.name = name;
       return new CanBeBound();
     }
 
+    @NonNull
     public <A extends Annotation> CanBeBound withName(
-        Class<A> annotationClassWithQualifierAnnotation) {
+        @NonNull Class<A> annotationClassWithQualifierAnnotation) {
       if (!annotationClassWithQualifierAnnotation.isAnnotationPresent(Qualifier.class)) {
         throw new IllegalArgumentException(
             String.format(
@@ -124,17 +135,19 @@ public class Binding<T> {
       return new CanBeReleasable();
     }
 
-    public void toInstance(T instance) {
+    public void toInstance(@NonNull T instance) {
       Binding.this.instance = instance;
       mode = Mode.INSTANCE;
     }
 
-    public CanBeSingleton to(Class<? extends T> implClass) {
+    @NonNull
+    public CanBeSingleton to(@NonNull Class<? extends T> implClass) {
       Binding.this.implementationClass = implClass;
       mode = Mode.CLASS;
       return new CanBeSingleton();
     }
 
+    @NonNull
     public CanProvideSingletonOrSingleton toProvider(
         Class<? extends Provider<? extends T>> providerClass) {
       Binding.this.providerClass = providerClass;
@@ -142,7 +155,8 @@ public class Binding<T> {
       return new CanProvideSingletonOrSingleton();
     }
 
-    public CanProvideSingleton toProviderInstance(Provider<? extends T> providerInstance) {
+    @NonNull
+    public CanProvideSingleton toProviderInstance(@NonNull Provider<? extends T> providerInstance) {
       Binding.this.providerInstance = providerInstance;
       mode = Mode.PROVIDER_INSTANCE;
       return new CanProvideSingleton();
@@ -151,6 +165,7 @@ public class Binding<T> {
 
   public class CanBeSingleton {
     /** to provide a singleton using the binding's scope and reuse it inside the binding's scope */
+    @NonNull
     public CanBeReleasable singleton() {
       Binding.this.isCreatingSingleton = true;
       return new CanBeReleasable();
@@ -165,6 +180,7 @@ public class Binding<T> {
   }
 
   public class CanProvideSingleton {
+    @NonNull
     public CanProvideReleasable providesSingleton() {
       isProvidingSingleton = true;
       return new CanProvideReleasable();
@@ -178,6 +194,7 @@ public class Binding<T> {
   }
 
   public class CanProvideSingletonOrSingleton extends CanBeSingleton {
+    @NonNull
     public CanProvideReleasableAndThenOnlySingleton providesSingleton() {
       isProvidingSingleton = true;
       return new CanProvideReleasableAndThenOnlySingleton();
@@ -185,6 +202,7 @@ public class Binding<T> {
   }
 
   public class CanProvideReleasableAndThenOnlySingleton {
+    @NonNull
     public CanBeOnlySingleton providesReleasable() {
       Binding.this.isProvidingReleasable = true;
       return new CanBeOnlySingleton();

--- a/toothpick/src/main/java/toothpick/config/Module.java
+++ b/toothpick/src/main/java/toothpick/config/Module.java
@@ -16,6 +16,7 @@
  */
 package toothpick.config;
 
+import androidx.annotation.NonNull;
 import java.util.HashSet;
 import java.util.Set;
 import toothpick.ProvidesSingleton;
@@ -99,12 +100,14 @@ import toothpick.ProvidesSingleton;
 public class Module {
   private Set<Binding> bindingSet = new HashSet<>();
 
-  public <T> Binding<T>.CanBeNamed bind(Class<T> key) {
+  @NonNull
+  public <T> Binding<T>.CanBeNamed bind(@NonNull Class<T> key) {
     Binding<T> binding = new Binding<>(key);
     bindingSet.add(binding);
     return binding.new CanBeNamed();
   }
 
+  @NonNull
   public Set<Binding> getBindingSet() {
     return bindingSet;
   }


### PR DESCRIPTION
- add androidx.annotation dependency to every modules
- add nullability annotations to Toothpick api that is used by KTP

I know this make a dependency of Android to Toothpick, but as it is just annotation, I thinks this is acceptable. Comment or better solutions are welcome