### PR TITLE
Fix tests for Windows developers

### DIFF
--- a/toothpick-runtime/src/main/java/toothpick/configuration/CyclicDependencyException.java
+++ b/toothpick-runtime/src/main/java/toothpick/configuration/CyclicDependencyException.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class CyclicDependencyException extends RuntimeException {
 
   private static final int MARGIN_SIZE = 3;
-  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+  private static final String LINE_SEPARATOR = "\n";
 
   CyclicDependencyException() {}
 
@@ -45,7 +45,7 @@ public class CyclicDependencyException extends RuntimeException {
   CyclicDependencyException(List<Class<?>> path, Class startClass) {
     this(
         String.format(
-            "Class %s creates a cycle:%n%s", startClass.getName(), format(path, startClass)));
+            "Class %s creates a cycle:\n%s", startClass.getName(), format(path, startClass)));
   }
 
   private static String format(List<Class<?>> path, Class startClass) {

--- a/toothpick-runtime/src/test/java/toothpick/concurrency/utils/ClassCreator.java
+++ b/toothpick-runtime/src/test/java/toothpick/concurrency/utils/ClassCreator.java
@@ -16,6 +16,7 @@
  */
 package toothpick.concurrency.utils;
 
+import javax.tools.*;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -24,12 +25,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.tools.Diagnostic;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.SimpleJavaFileObject;
-import javax.tools.ToolProvider;
 
 // from http://stackoverflow.com/a/2320465/693752
 
@@ -94,7 +89,7 @@ public class ClassCreator {
     if (!task.call()) {
       for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics.getDiagnostics()) {
         System.out.format(
-            "Error on line %d in %s%n", diagnostic.getLineNumber(), diagnostic.getSource());
+            "Error on line %d in %s\n", diagnostic.getLineNumber(), diagnostic.getSource());
       }
       return null;
     }


### PR DESCRIPTION
When executing `./gradlew check` on Windows in fails due to end-of-line characters.

The issue is described here:
#431

In this PR I propose to use `\n` to be platform-agnostic, as it also work on Windows.